### PR TITLE
GLES3

### DIFF
--- a/example/example_gles3.c
+++ b/example/example_gles3.c
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2013 Mikko Mononen memon@inside.org
+//
+// This software is provided 'as-is', without any express or implied
+// warranty.  In no event will the authors be held liable for any damages
+// arising from the use of this software.
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would be
+//    appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//    misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+//
+
+#include <stdio.h>
+#define GLFW_INCLUDE_ES3
+#include <GLFW/glfw3.h>
+#include "nanovg.h"
+#define NANOVG_GL3_IMPLEMENTATION
+#define NANOVG_GLES3
+#include "nanovg_gl3.h"
+#include "demo.h"
+
+
+void errorcb(int error, const char* desc)
+{
+	printf("GLFW error: %s\n", desc);
+}
+
+int blowup = 0;
+
+static void key(GLFWwindow* window, int key, int scancode, int action, int mods)
+{
+	if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)
+		glfwSetWindowShouldClose(window, GL_TRUE);
+	if (key == GLFW_KEY_SPACE && action == GLFW_PRESS)
+		blowup = !blowup;
+}
+
+int main()
+{
+	GLFWwindow* window;
+	struct DemoData data;
+	struct NVGcontext* vg = NULL;
+	struct FPScounter fps;
+	double prevt = 0;
+
+	if (!glfwInit()) {
+		printf("Failed to init GLFW.");
+		return -1;
+	}
+
+	initFPS(&fps);
+
+	glfwSetErrorCallback(errorcb);
+
+	glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+
+	window = glfwCreateWindow(1000, 600, "NanoVG", NULL, NULL);
+//	window = glfwCreateWindow(1000, 600, "NanoVG", glfwGetPrimaryMonitor(), NULL);
+	if (!window) {
+		glfwTerminate();
+		return -1;
+	}
+
+	glfwSetKeyCallback(window, key);
+
+	glfwMakeContextCurrent(window);
+
+	vg = nvgCreateGL3(512, 512, NVG_ANTIALIAS);
+	if (vg == NULL) {
+		printf("Could not init nanovg.\n");
+		return -1;
+	}
+
+	if (loadDemoData(vg, &data) == -1)
+		return -1;
+
+	glfwSwapInterval(0);
+
+	glfwSetTime(0);
+	prevt = glfwGetTime();
+
+	while (!glfwWindowShouldClose(window))
+	{
+		double mx, my, t, dt;
+		int width, height;
+
+		t = glfwGetTime();
+		dt = t - prevt;
+		prevt = t;
+		updateFPS(&fps, dt);
+
+		glfwGetCursorPos(window, &mx, &my);
+		glfwGetFramebufferSize(window, &width, &height);
+
+		// Update and render
+		glViewport(0, 0, width, height);
+		glClearColor(0.3f, 0.3f, 0.32f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_STENCIL_BUFFER_BIT);
+		glEnable(GL_BLEND);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		glEnable(GL_CULL_FACE);
+		glDisable(GL_DEPTH_TEST);
+
+		nvgBeginFrame(vg, width, height);
+
+		renderDemo(vg, mx,my, width,height, t, blowup, &data);
+		renderFPS(vg, 5,5, &fps);
+
+		glEnable(GL_DEPTH_TEST);
+
+		glfwSwapBuffers(window);
+		glfwPollEvents();
+	}
+
+	freeDemoData(vg, &data);
+
+	nvgDeleteGL3(vg);
+
+	glfwTerminate();
+	return 0;
+}

--- a/premake4.lua
+++ b/premake4.lua
@@ -132,8 +132,33 @@ solution "nanovg"
 		links { "nanovg" }
 	 
 		configuration { "linux" }
-			 links { "X11","Xrandr", "rt", "GL", "GLU", "pthread", "m", "glfw3", "GLEW" }
-			 defines { "NANOVG_GLEW" }
+			 links { "X11","Xrandr", "rt", "GL", "GLU", "pthread", "m", "glfw3" }
+
+		configuration { "windows" }
+			 links { "glu32","opengl32", "gdi32", "winmm", "user32" }
+
+		configuration { "macosx" }
+			links { "glfw3" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+
+		configuration "Debug"
+			defines { "DEBUG" }
+			flags { "Symbols", "ExtraWarnings"}
+
+		configuration "Release"
+			defines { "NDEBUG" }
+			flags { "Optimize", "ExtraWarnings"}
+
+	project "example_gles3"
+		kind "ConsoleApp"
+		language "C"
+		files { "example/example_gles3.c", "example/demo.c" }
+		includedirs { "src", "example" }
+		targetdir("build")
+		links { "nanovg" }
+	 
+		configuration { "linux" }
+			 links { "X11","Xrandr", "rt", "GL", "GLU", "pthread", "m", "glfw3" }
 
 		configuration { "windows" }
 			 links { "glu32","opengl32", "gdi32", "winmm", "user32" }

--- a/src/nanovg_gl3.h
+++ b/src/nanovg_gl3.h
@@ -248,7 +248,12 @@ static int glnvg__renderCreate(void* uptr)
 	struct GLNVGcontext* gl = (struct GLNVGcontext*)uptr;
 
 	static const char* fillVertShader =
+#ifdef NANOVG_GLES3
+		"#version 300 es\n"
+		"precision mediump float;\n"
+#else
 		"#version 150 core\n"
+#endif
 		"uniform vec2 viewSize;\n"
 		"in vec2 vertex;\n"
 		"in vec2 tcoord;\n"
@@ -264,7 +269,12 @@ static int glnvg__renderCreate(void* uptr)
 		"}\n";
 
 	static const char* fillFragShaderEdgeAA = 
+#ifdef NANOVG_GLES3
+		"#version 300 es\n"
+		"precision mediump float;\n"
+#else
 		"#version 150 core\n"
+#endif
 		"uniform mat3 scissorMat;\n"
 		"uniform vec2 scissorExt;\n"
 		"uniform mat3 paintMat;\n"
@@ -330,7 +340,12 @@ static int glnvg__renderCreate(void* uptr)
 		"}\n";
 
 	static const char* fillFragShader = 
+#ifdef NANOVG_GLES3
+		"#version 300 es\n"
+		"precision mediump float;\n"
+#else
 		"#version 150 core\n"
+#endif
 		"uniform mat3 scissorMat;\n"
 		"uniform vec2 scissorExt;\n"
 		"uniform mat3 paintMat;\n"
@@ -429,7 +444,11 @@ static int glnvg__renderCreateTexture(void* uptr, int type, int w, int h, const 
 	if (type == NVG_TEXTURE_RGBA)
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 	else
+#ifdef NANOVG_GLES3
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
+#else
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, data);
+#endif
 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -462,7 +481,11 @@ static int glnvg__renderUpdateTexture(void* uptr, int image, int x, int y, int w
 	if (tex->type == NVG_TEXTURE_RGBA)
 		glTexSubImage2D(GL_TEXTURE_2D, 0, x,y, w,h, GL_RGBA, GL_UNSIGNED_BYTE, data);
 	else
+#ifdef NANOVG_GLES3
+		glTexSubImage2D(GL_TEXTURE_2D, 0, x,y, w,h, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
+#else
 		glTexSubImage2D(GL_TEXTURE_2D, 0, x,y, w,h, GL_RED, GL_UNSIGNED_BYTE, data);
+#endif
 
 	return 1;
 }


### PR DESCRIPTION
@memononen Similar to what you did between the GL2 and GLES2 renderer, I did the same between 3.2 core and GLES3.

Known issue, on my Ubuntu 13.10, Intel Sandybridge GPU, Mesa 9.2.1 laptop, the following causes the code to fail:

```
    glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
```

A workaround is to instead request an OpenGL ES 2.0 context, which on this system, still results in an OpenGL ES 3.0 context, and then everything runs fine.

```
    glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
```
