### PR TITLE
Timing for CPU inner frame and GPU inner frame added

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -862,7 +862,12 @@ void updateFPS(struct FPScounter* fps, float frameTime)
 
 #define AVG_SIZE 20
 
-void renderFPS(struct NVGcontext* vg, float x, float y, struct FPScounter* fps, enum FPSRenderStyle style, const char* name)
+void renderFPS(struct NVGcontext* vg, float x, float y, struct FPScounter* fps)
+{
+	renderFPSEx(vg,x,y,fps,RENDER_FPS,NULL);
+}
+
+void renderFPSEx(struct NVGcontext* vg, float x, float y, struct FPScounter* fps, enum FPSRenderStyle style, const char* name)
 {
 	int i, head;
 	float avg, w, h;

--- a/example/demo.h
+++ b/example/demo.h
@@ -29,7 +29,8 @@ struct FPScounter
 
 void initFPS(struct FPScounter* fps);
 void updateFPS(struct FPScounter* fps, float frameTime);
-void renderFPS(struct NVGcontext* vg, float x, float y, struct FPScounter* fps, enum FPSRenderStyle style, const char* name );
+void renderFPSEx(struct NVGcontext* vg, float x, float y, struct FPScounter* fps, enum FPSRenderStyle style, const char* name );
+void renderFPS(struct NVGcontext* vg, float x, float y, struct FPScounter* fps);
 
 #ifdef __cplusplus
 }

--- a/example/example_gl3.c
+++ b/example/example_gl3.c
@@ -159,9 +159,9 @@ int main()
 		nvgBeginFrame(vg, winWidth, winHeight, pxRatio);
 
 		renderDemo(vg, mx,my, winWidth,winHeight, t, blowup, &data);
-		renderFPS(vg, 5,5, &fps, RENDER_FPS, NULL );
-		renderFPS(vg, 310,5, &cpuTimes, RENDER_MS, "CPU Time");
-		renderFPS(vg, 615,5, &gpuTimes, RENDER_MS, "GPU Time");
+		renderFPS(vg, 5,5, &fps);
+		renderFPSEx(vg, 310,5, &cpuTimes, RENDER_MS, "CPU Time");
+		renderFPSEx(vg, 615,5, &gpuTimes, RENDER_MS, "GPU Time");
 
 		nvgEndFrame(vg);
 


### PR DESCRIPTION
I've added two extra timers, and a renderFPSEx function to cope.

On Windows and Linux GLEW is likely required for the GPU timer query to compile. On OS X it should be part of the GL headers back to 10.7 as far as I can tell, but I've not tried. We could have an optional #define to remove these or to implement the prototype if needed.

The current naming for renderFPSEx and other functions is a bit abused here, but I've left renaming as an exercise for the repo owner, feel free to ask for changes and I can do them.

On the visual side it would be somewhat nicer for the counters to be vertically aligned, but doing so would need moving things around so I've not done that.

The timers don't time the frame swap, so as to more closely represent the actual cost of the  nanovg rendering. On my system the CPU and GPU times are roughly balanced until I go fullscreen, where the GPU cost becomes slightly larger. Using the zoom function also increases GPU cost when fullscreen. The clear is being measured here on the GPU, potentially along with any waiting for the data to be uploaded - so it's not a pure measure of the draw call costs which would need moving the timer before the nvgEndFrame function - but this wouldn't time calls for the unbuffered implementation.
