### PR TITLE
Reset pixel storage settings after load texture.

### DIFF
--- a/src/nanovg_gl3buf.h
+++ b/src/nanovg_gl3buf.h
@@ -447,12 +447,19 @@ static int glnvg__renderCreateTexture(void* uptr, int type, int w, int h, const 
 {
 	struct GLNVGcontext* gl = (struct GLNVGcontext*)uptr;
 	struct GLNVGtexture* tex = glnvg__allocTexture(gl);
+	int align,length,pixels,rows;
+
 	if (tex == NULL) return 0;
 	glGenTextures(1, &tex->tex);
 	tex->width = w;
 	tex->height = h;
 	tex->type = type;
 	glBindTexture(GL_TEXTURE_2D, tex->tex);
+
+	glGetIntegerv(GL_UNPACK_ALIGNMENT,&align);
+	glGetIntegerv(GL_UNPACK_ROW_LENGTH,&length);
+	glGetIntegerv(GL_UNPACK_SKIP_PIXELS,&pixels);
+	glGetIntegerv(GL_UNPACK_SKIP_ROWS,&rows);
 
 	glPixelStorei(GL_UNPACK_ALIGNMENT,1);
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, tex->width);
@@ -471,11 +478,17 @@ static int glnvg__renderCreateTexture(void* uptr, int type, int w, int h, const 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
+	glPixelStorei(GL_UNPACK_ALIGNMENT,align);
+	glPixelStorei(GL_UNPACK_ROW_LENGTH,length);
+	glPixelStorei(GL_UNPACK_SKIP_PIXELS,pixels);
+	glPixelStorei(GL_UNPACK_SKIP_ROWS,rows);
+
 	if (glnvg__checkError("create tex"))
 		return 0;
 
 	return tex->id;
 }
+
 
 static int glnvg__renderDeleteTexture(void* uptr, int image)
 {


### PR DESCRIPTION
Without this change integration with other rendering has a danger of crashing or wrong texture load due to incorrect pixel storage settings.
