### PR TITLE
add support for MinGW.

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -13,7 +13,7 @@
 
 #ifdef _MSC_VER
 #define snprintf _snprintf
-#else
+#elif !defined(__MINGW32__)
 #include <iconv.h>
 #endif
 

--- a/example/perf.c
+++ b/example/perf.c
@@ -10,7 +10,7 @@
 
 #ifdef _MSC_VER
 #define snprintf _snprintf
-#else
+#elif !defined(__MINGW32__)
 #include <iconv.h>
 #endif
 

--- a/premake4.lua
+++ b/premake4.lua
@@ -34,7 +34,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "windows" }
-			 links { "glu32","opengl32", "gdi32", "winmm", "user32", "glfw3", "GLEW" }
+			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32" }
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "macosx" }
@@ -62,7 +62,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "windows" }
-			 links { "glu32","opengl32", "gdi32", "winmm", "user32", "glfw3", "GLEW" }
+			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32" }
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "macosx" }
@@ -91,7 +91,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "windows" }
-			 links { "glu32","opengl32", "gdi32", "winmm", "user32", "glfw3", "GLEW" }
+			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32" }
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "macosx" }
@@ -120,7 +120,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "windows" }
-			 links { "glu32","opengl32", "gdi32", "winmm", "user32", "glfw3", "GLEW" }
+			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32" }
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "macosx" }
@@ -147,7 +147,7 @@ solution "nanovg"
 			 links { "X11","Xrandr", "rt", "GL", "GLU", "pthread", "m", "glfw3" }
 
 		configuration { "windows" }
-			 links { "glu32","opengl32", "gdi32", "winmm", "user32", "glfw3", "GLEW" }
+			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32" }
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "macosx" }
@@ -174,7 +174,7 @@ solution "nanovg"
 			 links { "X11","Xrandr", "rt", "GL", "GLU", "pthread", "m", "glfw3" }
 
 		configuration { "windows" }
-			 links { "glu32","opengl32", "gdi32", "winmm", "user32", "glfw3", "GLEW" }
+			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32" }
 			 defines { "NANOVG_GLEW" }
 
 		configuration { "macosx" }


### PR DESCRIPTION
this pull request for #64. using build NanoVG on Windows with MinGW.

using premake4 gmake to generate makefile, and use MinGW to compile.

tested on MinGW, do not tested on VC, yet.
