### PR TITLE
Removed GLFW 2 option macro

### DIFF
--- a/example/example_gl3.c
+++ b/example/example_gl3.c
@@ -20,7 +20,6 @@
 #ifdef NANOVG_GLEW
 #	include <GL/glew.h>
 #endif
-#define GLFW_NO_GLU
 #ifdef __APPLE__
 #	define GLFW_INCLUDE_GLCOREARB
 #endif


### PR DESCRIPTION
`GLFW_NO_GLU` is a GLFW 2 feature.  GLFW 3 does not include the GLU header by default.
