### PR TITLE
Fix some warnings on VS2013 /W4

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -24,6 +24,11 @@
 #define STBI_HEADER_FILE_ONLY
 #include "stb_image.c"
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4127)  // conditional expression is constant
+#pragma warning(disable: 4204)  // nonstandard extension used : non-constant aggregate initializer
+#pragma warning(disable: 4706)  // assignment within conditional expression
+#endif
 
 #define NVG_INIT_COMMANDS_SIZE 256
 #define NVG_INIT_POINTS_SIZE 128
@@ -973,7 +978,7 @@ static void nvg__addPoint(struct NVGcontext* ctx, float x, float y, int flags)
 	memset(pt, 0, sizeof(*pt));
 	pt->x = x;
 	pt->y = y;
-	pt->flags = flags;
+	pt->flags = (unsigned char)flags;
 
 	ctx->cache->npoints++;
 	path->count++;

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -25,6 +25,11 @@ extern "C" {
 
 #define NVG_PI 3.14159265358979323846264338327f
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4201)  // nonstandard extension used : nameless struct/union
+#endif
+
 struct NVGcontext;
 
 struct NVGcolor {
@@ -583,7 +588,15 @@ void nvgDeleteInternal(struct NVGcontext* ctx);
 // Debug function to dump cached path data.
 void nvgDebugDumpPathCache(struct NVGcontext* ctx);
 
+#ifdef _MSC_VER
+#define NVG_NOTUSED(v) ((void)(v))
+#else
 #define NVG_NOTUSED(v) do { (void)(1 ? (void)0 : ( (void)(v) ) ); } while(0)
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -803,7 +803,7 @@ static void glnvg__fill(struct GLNVGcontext* gl, struct GLNVGcall* call)
 	// Draw shapes
 	glEnable(GL_STENCIL_TEST);
 	glStencilMask(0xff);
-	glStencilFunc(GL_ALWAYS, 0, ~0L);
+	glStencilFunc(GL_ALWAYS, 0, (GLuint)(~0L));
 	glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
 	// set bindpoint for solid loc


### PR DESCRIPTION
Minor fixes/disables to compile warning free on VS2013 at /W4.
