### PR TITLE
add FBO support to NanoVG.

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -242,6 +242,11 @@ error:
 	return 0;
 }
 
+struct NVGparams* nvgInternalParams(struct NVGcontext* ctx)
+{
+    return &ctx->params;
+}
+
 void nvgDeleteInternal(struct NVGcontext* ctx)
 {
 	if (ctx == NULL) return;

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -580,6 +580,8 @@ struct NVGparams {
 struct NVGcontext* nvgCreateInternal(struct NVGparams* params);
 void nvgDeleteInternal(struct NVGcontext* ctx);
 
+struct NVGparams* nvgInternalParams(struct NVGcontext* ctx);
+
 // Debug function to dump cached path data.
 void nvgDebugDumpPathCache(struct NVGcontext* ctx);
 

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -62,6 +62,9 @@ void nvgDeleteGLES3(struct NVGcontext* ctx);
 
 #endif
 
+int nvgCreateImageGL(struct NVGcontext* ctx, int textureId);
+int nvgImageHandlerGL(struct NVGcontext* ctx, int image);
+
 #ifdef __cplusplus
 }
 #endif
@@ -1288,6 +1291,30 @@ void nvgDeleteGLES3(struct NVGcontext* ctx)
 #endif
 {
 	nvgDeleteInternal(ctx);
+}
+
+int nvgCreateImageGL(struct NVGcontext* ctx, int textureId)
+{
+	struct GLNVGcontext* gl = (struct GLNVGcontext*)nvgInternalParams(ctx)->userPtr;
+	struct GLNVGtexture* tex = glnvg__allocTexture(gl);
+
+	if (tex == NULL) return 0;
+
+	tex->tex = textureId;
+	tex->type = NVG_TEXTURE_RGBA;
+	glBindTexture(GL_TEXTURE_2D, tex->tex);
+	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &tex->width);
+	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &tex->height);
+	glBindTexture(GL_TEXTURE_2D, 0);
+
+	return tex->id;
+}
+
+int nvgImageHandlerGL(struct NVGcontext* ctx, int image)
+{
+	struct GLNVGcontext* gl = (struct GLNVGcontext*)nvgInternalParams(ctx)->userPtr;
+	struct GLNVGtexture* tex = glnvg__findTexture(gl, image);
+	return tex->tex;
 }
 
 #endif


### PR DESCRIPTION
This is another way to implement #90. the difference between #97 is:
- it add stencil buffer.
- add new interface `nvgBeginFrameTarget`

there is a issue about this request: it draws image up-side down (so as #97), @memononen hopes solution for this.
