### PR TITLE
Use highp precision when available for GLES

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -384,11 +384,15 @@ static int glnvg__renderCreate(void* uptr)
 		"#define NANOVG_GL3 1\n";
 #elif defined NANOVG_GLES2
 		"#version 100\n"
-		"precision mediump float;\n"
+		"#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
+		" precision highp float;\n"
+		"#else\n"
+		" precision mediump float;\n"
+		"#endif\n"
 		"#define NANOVG_GL2 1\n";
 #elif defined NANOVG_GLES3
 		"#version 300 es\n"
-		"precision mediump float;\n"
+		"precision highp float;\n"
 		"#define NANOVG_GL3 1\n";
 #endif
 


### PR DESCRIPTION
This is a fix for the shader precision issue in #46. It tries to use highp but falls back to mediump if necessary.

I made a .gif to illustrate the difference:

![hi-vs-med](https://cloud.githubusercontent.com/assets/27721/3210465/4501c75e-eec4-11e3-9ae1-59768283048f.gif)
