### PR TITLE
Allow to use glBlendFunc() for custom blending.

### DIFF
--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -86,6 +86,7 @@ enum NVGalign {
 enum NVGalpha {
 	NVG_STRAIGHT_ALPHA,
 	NVG_PREMULTIPLIED_ALPHA,
+	NVG_CUSTOM_ALPHA,
 };
 
 struct NVGglyphPosition {

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -969,7 +969,7 @@ static void glnvg__renderFlush(void* uptr, int alphaBlend)
 
 		if (alphaBlend == NVG_PREMULTIPLIED_ALPHA)
 			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-		else
+		else if (alphaBlend == NVG_STRAIGHT_ALPHA)
 			glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 		glEnable(GL_CULL_FACE);
 		glCullFace(GL_BACK);


### PR DESCRIPTION
This pull request tries to ease the situation described in #88. Originally there are only NVG_STRAIGHT_ALPHA and NVG_PREMULTIPLIED_ALPHA for alpha blend. This would cause any custom glBlendFunc() calls to be ignored. This commit simply adds NVG_CUSTOM_ALPHA to make glBlendFunc() calls working.
