### PR TITLE
Fix runtime error under VS2013

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -1444,7 +1444,7 @@ static void nvg__calculateJoins(struct NVGcontext* ctx, float w, int lineJoin, f
 {
 	struct NVGpathCache* cache = ctx->cache;
 	int i, j;
-	float iw;
+	float iw = 0.0f;
 
 	if (w > 0.0f) iw = 1.0f / w;
 


### PR DESCRIPTION
In the event that 'iw' is never set, the VS2013 debugger will throw a
runtime error if the application attempts to use it.
