### PR TITLE
allows for nanovg_gl prototypes to be declared simultaneously

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -55,17 +55,23 @@ extern "C" {
 struct NVGcontext* nvgCreateGL2(int atlasw, int atlash, int flags);
 void nvgDeleteGL2(struct NVGcontext* ctx);
 
-#elif defined NANOVG_GL3
+#endif
+
+#if defined NANOVG_GL3
 
 struct NVGcontext* nvgCreateGL3(int atlasw, int atlash, int flags);
 void nvgDeleteGL3(struct NVGcontext* ctx);
 
-#elif defined NANOVG_GLES2
+#endif
+
+#if defined NANOVG_GLES2
 
 struct NVGcontext* nvgCreateGLES2(int atlasw, int atlash, int edgeaa);
 void nvgDeleteGLES2(struct NVGcontext* ctx);
 
-#elif defined NANOVG_GLES3
+#endif
+
+#if defined NANOVG_GLES3
 
 struct NVGcontext* nvgCreateGLES3(int atlasw, int atlash, int edgeaa);
 void nvgDeleteGLES3(struct NVGcontext* ctx);


### PR DESCRIPTION
This is a simple fix to enable `#incldue <nanovg_gl.h>`to define prototypes for the various backends simultaneously.

This is an absolute requirement for my code.  Previously, I included `nanovg_gl.h` multiple times with an `#undef NANOVG_GL3_H` (or `#undef NANOVG_GL_H`) after each instance.  That workaround is no longer possible since then, e.g., `NVGLtextureflags`  would now be declared multiple times.  The present solution is much more elegant anyway.
