### PR TITLE
only specify precision for fragment shader

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -448,7 +448,7 @@ static int glnvg__renderCreate(void* uptr)
 		"#else\n"
 		" precision mediump float;\n"
 		"#endif\n"
-    	"#endif\n"
+		"#endif\n"
 		"#ifdef NANOVG_GL3\n"
 		"#ifdef USE_UNIFORMBUFFER\n"
 		"	layout(std140) uniform frag {\n"


### PR DESCRIPTION
Per discussion in #106, this should avoid unnecessarily reverting to mediump in the vertex shader.

Note, the GL_ES macro is built-in to GLSL-ES.

I tested this code on my Intel GPU with the open-source Mesa driver.  It works for both GLES2 and GLES3.  But I don't know if you might want feedback from those (@olliwang) developing on true GLES2 devices before merging. 
