### PR TITLE
Allow more control when glGetError is called, and don't call when NDEBUG is defined

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -336,7 +336,11 @@ static int glnvg__checkError(const char* str)
 	return 0;
 }
 #else
-#define glnvg__checkError(str) (0)
+static int glnvg__checkError(const char* str)
+{
+    (void)(str); // silence unused warning
+    return 0;
+}
 #endif
 
 static int glnvg__createShader(GLNVGshader* shader, const char* name, const char* header, const char* opts, const char* vshader, const char* fshader)


### PR DESCRIPTION
Proposed solution for issue #150 , I am assuming that NDEBUG is the universal convention for "release mode with optimizations" and define glnvg__checkError as (0) if set, additionally allow to override this behaviour with a force-on and force-off flag.
