### PR TITLE
Fix texture completeness for non-POT textures on GLES2/WebGL

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -663,6 +663,9 @@ static int glnvg__renderCreateTexture(void* uptr, int type, int w, int h, int im
     }
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 #ifndef NANOVG_GLES2
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);


### PR DESCRIPTION
Proposed solution for issue #151 , this simply forces the TEXTURE_WRAP_S/T state to CLAMP_TO_EDGE when creating a texture. This is only required for non-power-of-2 textures on GLES2/WebGL, but I assume that this is wanted behaviour for all textures.
