### PR TITLE
Added nvgCancelFrame()

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -300,6 +300,11 @@ void nvgBeginFrame(NVGcontext* ctx, int windowWidth, int windowHeight, float dev
 	ctx->textTriCount = 0;
 }
 
+void nvgCancelFrame(NVGcontext* ctx)
+{
+	ctx->params.renderCancel(ctx->params.userPtr);
+}
+
 void nvgEndFrame(NVGcontext* ctx)
 {
 	ctx->params.renderFlush(ctx->params.userPtr);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -117,6 +117,9 @@ enum NVGimageFlags {
 // devicePixelRatio to: frameBufferWidth / windowWidth.
 void nvgBeginFrame(NVGcontext* ctx, int windowWidth, int windowHeight, float devicePixelRatio);
 
+// Cancels drawing the current frame.
+void nvgCancelFrame(NVGcontext* ctx);
+
 // Ends drawing flushing remaining render state.
 void nvgEndFrame(NVGcontext* ctx);
 
@@ -586,6 +589,7 @@ struct NVGparams {
 	int (*renderUpdateTexture)(void* uptr, int image, int x, int y, int w, int h, const unsigned char* data);
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
 	void (*renderViewport)(void* uptr, int width, int height);
+	void (*renderCancel)(void* uptr);
 	void (*renderFlush)(void* uptr);
 	void (*renderFill)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, const float* bounds, const NVGpath* paths, int npaths);
 	void (*renderStroke)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, float strokeWidth, const NVGpath* paths, int npaths);

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -1006,6 +1006,14 @@ static void glnvg__triangles(GLNVGcontext* gl, GLNVGcall* call)
 	glDrawArrays(GL_TRIANGLES, call->triangleOffset, call->triangleCount);
 }
 
+static void glnvg__renderCancel(void* uptr) {
+	GLNVGcontext* gl = (GLNVGcontext*)uptr;
+	gl->nverts = 0;
+	gl->npaths = 0;
+	gl->ncalls = 0;
+	gl->nuniforms = 0;
+}
+
 static void glnvg__renderFlush(void* uptr)
 {
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
@@ -1398,6 +1406,7 @@ NVGcontext* nvgCreateGLES3(int flags)
 	params.renderUpdateTexture = glnvg__renderUpdateTexture;
 	params.renderGetTextureSize = glnvg__renderGetTextureSize;
 	params.renderViewport = glnvg__renderViewport;
+	params.renderCancel = glnvg__renderCancel;
 	params.renderFlush = glnvg__renderFlush;
 	params.renderFill = glnvg__renderFill;
 	params.renderStroke = glnvg__renderStroke;


### PR DESCRIPTION
This commit implements a new nvgCancelFrame() function for the purpose described in #168.

Currently, if calling nvgBeginFrame(), the nvgEndFrame() function must be called to finish the drawing. However, if knowing the drawing would take too much time and want to give up the drawing. There is no way to cancel it. nvgCancelFrame() gives another choice to end the frame without actually drawing.
