### PR TITLE
Fixed syntax error of checking defined identifier

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -1428,13 +1428,13 @@ error:
 	return NULL;
 }
 
-#if NANOVG_GL2
+#if defined NANOVG_GL2
 void nvgDeleteGL2(NVGcontext* ctx)
-#elif NANOVG_GL3
+#elif defined NANOVG_GL3
 void nvgDeleteGL3(NVGcontext* ctx)
-#elif NANOVG_GLES2
+#elif defined NANOVG_GLES2
 void nvgDeleteGLES2(NVGcontext* ctx)
-#elif NANOVG_GLES3
+#elif defined NANOVG_GLES3
 void nvgDeleteGLES3(NVGcontext* ctx)
 #endif
 {


### PR DESCRIPTION
EDIT: The original issue has been resolved in the discussion but a new bug has also been found. This pull request is changed to fix the syntax error of checking defined identifier to make the original purpose work as expected.

ORIGINAL TITLE: Fixed duplicate symbols issue
ORIGINAL DESCRIPTION:
The compiler will throw duplicate symbols error If including nanovg_gl_utils.h" or "nanovg_gl.h" in multiple source files.

This commit adds `static` in front of all functions in both header files to prevent from generating the error.
