### PR TITLE
Added missing function prototype of nvgluBindFramebuffer()

### DIFF
--- a/src/nanovg_gl_utils.h
+++ b/src/nanovg_gl_utils.h
@@ -29,6 +29,7 @@ typedef struct NVGLUframebuffer NVGLUframebuffer;
 
 // Helper function to create GL frame buffer to render to.
 NVGLUframebuffer* nvgluCreateFramebuffer(NVGcontext* ctx, int w, int h, int imageFlags);
+void nvgluBindFramebuffer(NVGLUframebuffer* fb);
 void nvgluDeleteFramebuffer(NVGcontext* ctx, NVGLUframebuffer* fb);
 
 #endif // NANOVG_GL_UTILS_H


### PR DESCRIPTION
The function prototype of nvgluBindFramebuffer() was missing. That would cause compiler error if the "nanovg_gl_utils.h" header file is included in multiple source files.
