### PR TITLE
Added check in addPoint to avoid duplicated moveTos breaking

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -1060,7 +1060,7 @@ static void nvg__addPoint(NVGcontext* ctx, float x, float y, int flags)
 	NVGpoint* pt;
 	if (path == NULL) return;
 
-	if (ctx->cache->npoints > 0) {
+	if (path->count > 0 && ctx->cache->npoints > 0) {
 		pt = nvg__lastPoint(ctx);
 		if (nvg__ptEquals(pt->x,pt->y, x,y, ctx->distTol)) {
 			pt->flags |= flags;


### PR DESCRIPTION
It guards addPoint from "stealing" the point from the previous path if they're the same, which makes it break when you do something like this:

```
moveTo(50, 50)
moveTo(50, 50)
lineTo(100, 100)
```

Before the fix there's no line shown. With the second moveTo, there's a second path added, but without the 50,50 point, because it was already added with the first moveTo. This makes the second path only contain the point 100,100 so it doesn't draw at all.

After the fix, the point equality check is ignored for the first point in the path, so the second path gets the 50,50 point too and that makes it behave as expected.

This is only one solution to the duplicated moveTo problem and it's likely not the best one, but it's one that's easy to add and it seems to work just fine.
