### PR TITLE
Adding nvgColorHex function

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -430,6 +430,24 @@ NVGcolor nvgHSLA(float h, float s, float l, unsigned char a)
 	return col;
 }
 
+NVGcolor nvgColorHex(unsigned int color)
+{
+	// input format 0xAARRGGBB
+	float b = (float)(0x000000FF & color) / 255.f;
+	color = color >> 8;
+	float g = (float)(0x000000FF & color) / 255.f;
+	color = color >> 8;
+	float r = (float)(0x000000FF & color) / 255.f;
+	color = color >> 8;
+	float a = (float)(0x000000FF & color) / 255.f;
+
+	NVGcolor nvgColor;
+	nvgColor.r = r;
+	nvgColor.g = g;
+	nvgColor.b = b;
+	nvgColor.a = a;
+	return nvgColor;
+}
 
 static NVGstate* nvg__getState(NVGcontext* ctx)
 {

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -159,6 +159,10 @@ NVGcolor nvgHSL(float h, float s, float l);
 // HSL values are all in range [0..1], alpha in range [0..255]
 NVGcolor nvgHSLA(float h, float s, float l, unsigned char a);
 
+// Returns a color value from input color with format 0xAARRGGBB
+NVGcolor nvgColorHex(unsigned int color);
+
+
 //
 // State Handling
 //


### PR DESCRIPTION
In my experience the colors that I am given from the design team are in hex format.  This patch allows those to be directly added to NanoVG