### PR TITLE
updated premake build script for osx with homebrew glfw libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,27 @@ to build examples on osx with homebrew glfw3 library
 * install [homebrew](http://brew.sh/)
 
 * install homebrew glfw3 lib
+
 	$ brew tap homebrew/versions
+
 	$ brew install --build-bottle glfw3
 
 * install homebrew premake
+
 	$ brew install premake
 
 * clone nanovg and cd into it
+
 	$ cd <build>/nanovg
 
 * use premake to build osx version of gnu make scripts
+
 	$ premake4 gmake --os=macosx premake4.lua
 
 * cd to build dir and make examples
+
 	$ cd build
+	
 	$ make
 
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,31 @@ NanoVG is small antialiased vector graphics rendering library for OpenGL. It has
 
 ![screenshot of some text rendered witht the sample program](/example/screenshot-01.png?raw=true)
 
+Building examples
+=================
+
+to build examples on osx with homebrew glfw3 library
+
+* install [homebrew](http://brew.sh/)
+
+* install homebrew glfw3 lib
+	$ brew tap homebrew/versions
+	$ brew install --build-bottle glfw3
+
+* install homebrew premake
+	$ brew install premake
+
+* clone nanovg and cd into it
+	$ cd <build>/nanovg
+
+* use premake to build osx version of gnu make scripts
+	$ premake4 gmake --os=macosx premake4.lua
+
+* cd to build dir and make examples
+	$ cd build
+	$ make
+
+
 Usage
 =====
 

--- a/premake4.lua
+++ b/premake4.lua
@@ -41,8 +41,8 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			buildoptions { "`pkg-config --cflags glfw3`" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "`pkg-config --libs glfw3`" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -70,8 +70,8 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			buildoptions { "`pkg-config --cflags glfw3`" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "`pkg-config --libs glfw3`" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -100,8 +100,8 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			buildoptions { "`pkg-config --cflags glfw3`" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "`pkg-config --libs glfw3`" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -130,8 +130,8 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			buildoptions { "`pkg-config --cflags glfw3`" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "`pkg-config --libs glfw3`" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -158,8 +158,8 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			buildoptions { "`pkg-config --cflags glfw3`" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "`pkg-config --libs glfw3`" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -186,8 +186,8 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			buildoptions { "`pkg-config --cflags glfw3`" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "`pkg-config --libs glfw3`" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -214,8 +214,8 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			buildoptions { "`pkg-config --cflags glfw3`" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "`pkg-config --libs glfw3`" }
 
 		configuration "Debug"
 			defines { "DEBUG" }


### PR DESCRIPTION
hi,

i am planning to use your library for a 2d rendering project, it looks really great so far! 

here are the changes i made to the premake build script to get it to work with osx (10.10) with homebrew libs. on my system the examples all build *except* the gles examples (i think because osx doesnt have opengl es libs?), i am planning to work with the gl3 implementation.

i also wrote up the build process to get the examples going and put it in the readme, im not sure if you really want it there? 

i am going to try to clean up [this cython interface](https://github.com/pupil-labs/pynanovg) so i can use nanovg with python :)

hope this is helpful!

thx,

mike