### PR TITLE
fixed type usage

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -363,8 +363,8 @@ static int glnvg__deleteTexture(GLNVGcontext* gl, int id)
 
 static void glnvg__dumpShaderError(GLuint shader, const char* name, const char* type)
 {
-	char str[512+1];
-	int len = 0;
+	GLchar str[512+1];
+	GLsizei len = 0;
 	glGetShaderInfoLog(shader, 512, &len, str);
 	if (len > 512) len = 512;
 	str[len] = '\0';
@@ -373,8 +373,8 @@ static void glnvg__dumpShaderError(GLuint shader, const char* name, const char* 
 
 static void glnvg__dumpProgramError(GLuint prog, const char* name)
 {
-	char str[512+1];
-	int len = 0;
+	GLchar str[512+1];
+	GLsizei len = 0;
 	glGetProgramInfoLog(prog, 512, &len, str);
 	if (len > 512) len = 512;
 	str[len] = '\0';


### PR DESCRIPTION
in some situations int and GLsizei are not the same type which leads to conversion warnings