### PR TITLE
Add support for bgfx

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -295,7 +295,7 @@ void nvgBeginFrame(NVGcontext* ctx, int windowWidth, int windowHeight, float dev
 
 	nvg__setDevicePixelRatio(ctx, devicePixelRatio);
 
-	ctx->params.renderViewport(ctx->params.userPtr, windowWidth, windowHeight);
+	ctx->params.renderViewport(ctx->params.userPtr, windowWidth, windowHeight, devicePixelRatio);
 
 	ctx->drawCallCount = 0;
 	ctx->fillTriCount = 0;

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -588,7 +588,7 @@ struct NVGparams {
 	int (*renderDeleteTexture)(void* uptr, int image);
 	int (*renderUpdateTexture)(void* uptr, int image, int x, int y, int w, int h, const unsigned char* data);
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
-	void (*renderViewport)(void* uptr, int width, int height);
+	void (*renderViewport)(void* uptr, int width, int height, float devicePixelRatio);
 	void (*renderCancel)(void* uptr);
 	void (*renderFlush)(void* uptr);
 	void (*renderFill)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, const float* bounds, const NVGpath* paths, int npaths);

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -941,7 +941,7 @@ static void glnvg__setUniforms(GLNVGcontext* gl, int uniformOffset, int image)
 	}
 }
 
-static void glnvg__renderViewport(void* uptr, int width, int height)
+static void glnvg__renderViewport(void* uptr, int width, int height, float devicePixelRatio)
 {
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
 	gl->view[0] = (float)width;


### PR DESCRIPTION
This commit updates the `nvgBeginFrame()` function to forward the received `devicePixelRatio` parameter to the `renderViewport()` function so it is possible to configure the environemnt correctly when using `bgfx` backend.

The current implementation of the `renderViewport()` function in bgfx backend is implemented in this line: https://github.com/bkaradzic/bgfx/blob/7de947c7c08acdc597bc0bd3f67f43e2bafd3760/examples/common/nanovg/nanovg_bgfx.cpp#L553 

However, the `bgfx::setViewRect()` function won't work properly if the passed width and height are not multiplied to the `devicePixelRatio`, and because `devicePixelRatio` is kept in `NVGcontext` and the `NVGcontext` object is only visible in the `nanovg.c` file. It seems that passing the `devicePixelRatio` parameter to the `renderViewport()` function is the only way to make `bgfx` backend works properly.