### PR TITLE
Implements composite operation for blending renderings.

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -338,6 +338,25 @@ void nvgEndFrame(NVGcontext* ctx)
 	}
 }
 
+NVGcompositeOperation nvgBlendFunc(int sfactor, int dfactor)
+{
+	return nvgBlendFuncSeparate(sfactor, dfactor, sfactor, dfactor);
+}
+
+NVGcompositeOperation nvgBlendFuncSeparate(int srcRGB, int dstRGB, int srcAlpha, int dstAlpha)
+{
+	NVGcompositeOperation operation;
+	operation.srcRGB = srcRGB;
+	operation.dstRGB = dstRGB;
+	operation.srcAlpha = srcAlpha;
+	operation.dstAlpha = dstAlpha;
+	return operation;
+}
+
+void nvgGlobalCompositeOperation(NVGcontext* ctx, NVGcompositeOperation op) {
+	ctx->params.renderCompositeOperation(ctx->params.userPtr, op);
+}
+
 NVGcolor nvgRGB(unsigned char r, unsigned char g, unsigned char b)
 {
 	return nvgRGBA(r,g,b,255);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -97,14 +97,6 @@ enum NVGblendFactor {
 	NVG_SRC_ALPHA_SATURATE = 1<<10,
 };
 
-struct NVGcompositeOperationState {
-	int srcRGB;
-	int dstRGB;
-	int srcAlpha;
-	int dstAlpha;
-};
-typedef struct NVGcompositeOperationState NVGcompositeOperationState;
-
 enum NVGcompositeOperation {
 	NVG_SOURCE_OVER,
 	NVG_SOURCE_IN,
@@ -118,6 +110,14 @@ enum NVGcompositeOperation {
 	NVG_COPY,
 	NVG_XOR,
 };
+
+struct NVGcompositeOperationState {
+	int srcRGB;
+	int dstRGB;
+	int srcAlpha;
+	int dstAlpha;
+};
+typedef struct NVGcompositeOperationState NVGcompositeOperationState;
 
 struct NVGglyphPosition {
 	const char* str;	// Position of the glyph in the input string.

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -162,9 +162,7 @@ void nvgEndFrame(NVGcontext* ctx);
 //
 // Composite operation
 //
-// Composite operation in NanoVG is applied only when calling nvgEndFrame()
-// instead of drawing API. The default composite operation of NanoVG is
-// NVG_SOURCE_OVER.
+// The default composite operation of NanoVG is NVG_SOURCE_OVER.
 
 // Sets the composite operation. The op parameter should be one of NVGcompositeOperation.
 void nvgGlobalCompositeOperation(NVGcontext* ctx, int op);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -162,7 +162,9 @@ void nvgEndFrame(NVGcontext* ctx);
 //
 // Composite operation
 //
-// The default composite operation of NanoVG is NVG_SOURCE_OVER.
+// The composite operations in NanoVG are modeled after HTML Canvas API, and
+// the blend func is based on OpenGL (see corresponding manuals for more info).
+// The colors in the blending state have premultiplied alpha.
 
 // Sets the composite operation. The op parameter should be one of NVGcompositeOperation.
 void nvgGlobalCompositeOperation(NVGcontext* ctx, int op);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -83,6 +83,41 @@ enum NVGalign {
 	NVG_ALIGN_BASELINE	= 1<<6, // Default, align text vertically to baseline. 
 };
 
+enum NVGblendFactor {
+	NVG_ZERO = 1<<0,
+	NVG_ONE = 1<<1,
+	NVG_SRC_COLOR = 1<<2,
+	NVG_ONE_MINUS_SRC_COLOR = 1<<3,
+	NVG_DST_COLOR = 1<<4,
+	NVG_ONE_MINUS_DST_COLOR = 1<<5,
+	NVG_SRC_ALPHA = 1<<6,
+	NVG_ONE_MINUS_SRC_ALPHA = 1<<7,
+	NVG_DST_ALPHA = 1<<8,
+	NVG_ONE_MINUS_DST_ALPHA = 1<<9,
+	NVG_SRC_ALPHA_SATURATE = 1<<10,
+};
+
+struct NVGcompositeOperation {
+	int srcRGB;
+	int dstRGB;
+	int srcAlpha;
+	int dstAlpha;
+};
+typedef struct NVGcompositeOperation NVGcompositeOperation;
+
+// Predefined composite operations.
+#define NVG_SOURCE_OVER nvgBlendFunc(NVG_ONE, NVG_ONE_MINUS_SRC_ALPHA)
+#define NVG_SOURCE_IN nvgBlendFunc(NVG_DST_ALPHA, NVG_ZERO)
+#define NVG_SOURCE_OUT nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA, NVG_ZERO)
+#define NVG_ATOP nvgBlendFunc(NVG_DST_ALPHA, NVG_ONE_MINUS_SRC_ALPHA)
+#define NVG_DESTINATION_OVER nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA, NVG_ONE)
+#define NVG_DESTINATION_IN nvgBlendFunc(NVG_ZERO, NVG_SRC_ALPHA)
+#define NVG_DESTINATION_OUT nvgBlendFunc(NVG_ZERO, NVG_ONE_MINUS_SRC_ALPHA)
+#define NVG_DESTINATION_ATOP nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA, NVG_SRC_ALPHA)
+#define NVG_LIGHTER nvgBlendFunc(NVG_ONE, NVG_ONE)
+#define NVG_COPY nvgBlendFunc(NVG_ONE, NVG_ZERO)
+#define NVG_XOR nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA NVG_ONE_MINUS_SRC_ALPHA)
+
 struct NVGglyphPosition {
 	const char* str;	// Position of the glyph in the input string.
 	float x;			// The x-coordinate of the logical glyph position.
@@ -122,6 +157,22 @@ void nvgCancelFrame(NVGcontext* ctx);
 
 // Ends drawing flushing remaining render state.
 void nvgEndFrame(NVGcontext* ctx);
+
+//
+// Composite operation
+//
+// Composite operation in NanoVG works between frames. The default composite
+// operation of NanoVG is NVG_SOURCE_OVER, and the value is reset whenever
+// calling nvgBeginFrame().
+
+// Creates a composite operation with custom pixel arithmetic. The parameters should be one of NVGblendFactor.
+NVGcompositeOperation nvgBlendFunc(int sfactor, int dfactor);
+
+// Creates a composite operation with custom pixel arithmetic for RGB and alpha components separately. The parameters should be one of NVGblendFactor.
+NVGcompositeOperation nvgBlendFuncSeparate(int srcRGB, int dstRGB, int srcAlpha, int dstAlpha);
+
+// Sets the composite operation for the current frame. This function should be called between nvgBeginFrame() and nvgEndFrame(). The default composite operation of NanoVG is NVG_SOURCE_OVER.
+void nvgGlobalCompositeOperation(NVGcontext* ctx, NVGcompositeOperation op);
 
 //
 // Color utils
@@ -590,6 +641,7 @@ struct NVGparams {
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
 	void (*renderViewport)(void* uptr, int width, int height, float devicePixelRatio);
 	void (*renderCancel)(void* uptr);
+	void (*renderCompositeOperation)(void* uptr, NVGcompositeOperation op);
 	void (*renderFlush)(void* uptr);
 	void (*renderFill)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, const float* bounds, const NVGpath* paths, int npaths);
 	void (*renderStroke)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, float strokeWidth, const NVGpath* paths, int npaths);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -97,26 +97,27 @@ enum NVGblendFactor {
 	NVG_SRC_ALPHA_SATURATE = 1<<10,
 };
 
-struct NVGcompositeOperation {
+struct NVGcompositeOperationState {
 	int srcRGB;
 	int dstRGB;
 	int srcAlpha;
 	int dstAlpha;
 };
-typedef struct NVGcompositeOperation NVGcompositeOperation;
+typedef struct NVGcompositeOperationState NVGcompositeOperationState;
 
-// Predefined composite operations.
-#define NVG_SOURCE_OVER nvgBlendFunc(NVG_ONE, NVG_ONE_MINUS_SRC_ALPHA)
-#define NVG_SOURCE_IN nvgBlendFunc(NVG_DST_ALPHA, NVG_ZERO)
-#define NVG_SOURCE_OUT nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA, NVG_ZERO)
-#define NVG_ATOP nvgBlendFunc(NVG_DST_ALPHA, NVG_ONE_MINUS_SRC_ALPHA)
-#define NVG_DESTINATION_OVER nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA, NVG_ONE)
-#define NVG_DESTINATION_IN nvgBlendFunc(NVG_ZERO, NVG_SRC_ALPHA)
-#define NVG_DESTINATION_OUT nvgBlendFunc(NVG_ZERO, NVG_ONE_MINUS_SRC_ALPHA)
-#define NVG_DESTINATION_ATOP nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA, NVG_SRC_ALPHA)
-#define NVG_LIGHTER nvgBlendFunc(NVG_ONE, NVG_ONE)
-#define NVG_COPY nvgBlendFunc(NVG_ONE, NVG_ZERO)
-#define NVG_XOR nvgBlendFunc(NVG_ONE_MINUS_DST_ALPHA NVG_ONE_MINUS_SRC_ALPHA)
+enum NVGcompositeOperation {
+	NVG_SOURCE_OVER,
+	NVG_SOURCE_IN,
+	NVG_SOURCE_OUT,
+	NVG_ATOP,
+	NVG_DESTINATION_OVER,
+	NVG_DESTINATION_IN,
+	NVG_DESTINATION_OUT,
+	NVG_DESTINATION_ATOP,
+	NVG_LIGHTER,
+	NVG_COPY,
+	NVG_XOR,
+};
 
 struct NVGglyphPosition {
 	const char* str;	// Position of the glyph in the input string.
@@ -162,17 +163,16 @@ void nvgEndFrame(NVGcontext* ctx);
 // Composite operation
 //
 // Composite operation in NanoVG works between frames. The default composite
-// operation of NanoVG is NVG_SOURCE_OVER, and the value is reset whenever
-// calling nvgBeginFrame().
+// operation of NanoVG is NVG_SOURCE_OVER.
 
-// Creates a composite operation with custom pixel arithmetic. The parameters should be one of NVGblendFactor.
-NVGcompositeOperation nvgBlendFunc(int sfactor, int dfactor);
+// Sets the composite operation. The op parameter should be one of NVGcompositeOperation.
+void nvgGlobalCompositeOperation(NVGcontext* ctx, int op);
 
-// Creates a composite operation with custom pixel arithmetic for RGB and alpha components separately. The parameters should be one of NVGblendFactor.
-NVGcompositeOperation nvgBlendFuncSeparate(int srcRGB, int dstRGB, int srcAlpha, int dstAlpha);
+// Sets the composite operation with custom pixel arithmetic. The parameters should be one of NVGblendFactor.
+void nvgGlobalCompositeBlendFunc(NVGcontext* ctx, int sfactor, int dfactor);
 
-// Sets the composite operation for the current frame. This function should be called between nvgBeginFrame() and nvgEndFrame(). The default composite operation of NanoVG is NVG_SOURCE_OVER.
-void nvgGlobalCompositeOperation(NVGcontext* ctx, NVGcompositeOperation op);
+// Sets the composite operation with custom pixel arithmetic for RGB and alpha components separately. The parameters should be one of NVGblendFactor.
+void nvgGlobalCompositeBlendFuncSeparate(NVGcontext* ctx, int srcRGB, int dstRGB, int srcAlpha, int dstAlpha);
 
 //
 // Color utils
@@ -641,8 +641,7 @@ struct NVGparams {
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
 	void (*renderViewport)(void* uptr, int width, int height, float devicePixelRatio);
 	void (*renderCancel)(void* uptr);
-	void (*renderCompositeOperation)(void* uptr, NVGcompositeOperation op);
-	void (*renderFlush)(void* uptr);
+	void (*renderFlush)(void* uptr, NVGcompositeOperationState compositeOperation);
 	void (*renderFill)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, const float* bounds, const NVGpath* paths, int npaths);
 	void (*renderStroke)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, float strokeWidth, const NVGpath* paths, int npaths);
 	void (*renderTriangles)(void* uptr, NVGpaint* paint, NVGscissor* scissor, const NVGvertex* verts, int nverts);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -79,8 +79,8 @@ enum NVGalign {
 	// Vertical align
 	NVG_ALIGN_TOP 		= 1<<3,	// Align text vertically to top.
 	NVG_ALIGN_MIDDLE	= 1<<4,	// Align text vertically to middle.
-	NVG_ALIGN_BOTTOM	= 1<<5,	// Align text vertically to bottom. 
-	NVG_ALIGN_BASELINE	= 1<<6, // Default, align text vertically to baseline. 
+	NVG_ALIGN_BOTTOM	= 1<<5,	// Align text vertically to bottom.
+	NVG_ALIGN_BASELINE	= 1<<6, // Default, align text vertically to baseline.
 };
 
 enum NVGblendFactor {
@@ -162,8 +162,9 @@ void nvgEndFrame(NVGcontext* ctx);
 //
 // Composite operation
 //
-// Composite operation in NanoVG works between frames. The default composite
-// operation of NanoVG is NVG_SOURCE_OVER.
+// Composite operation in NanoVG is applied only when calling nvgEndFrame()
+// instead of drawing API. The default composite operation of NanoVG is
+// NVG_SOURCE_OVER.
 
 // Sets the composite operation. The op parameter should be one of NVGcompositeOperation.
 void nvgGlobalCompositeOperation(NVGcontext* ctx, int op);
@@ -234,7 +235,7 @@ void nvgReset(NVGcontext* ctx);
 // Solid color is simply defined as a color value, different kinds of paints can be created
 // using nvgLinearGradient(), nvgBoxGradient(), nvgRadialGradient() and nvgImagePattern().
 //
-// Current render style can be saved and restored using nvgSave() and nvgRestore(). 
+// Current render style can be saved and restored using nvgSave() and nvgRestore().
 
 // Sets current stroke style to a solid color.
 void nvgStrokeColor(NVGcontext* ctx, NVGcolor color);
@@ -282,7 +283,7 @@ void nvgGlobalAlpha(NVGcontext* ctx, float alpha);
 // Apart from nvgResetTransform(), each transformation function first creates
 // specific transformation matrix and pre-multiplies the current transformation by it.
 //
-// Current coordinate system (transformation) can be saved and restored using nvgSave() and nvgRestore(). 
+// Current coordinate system (transformation) can be saved and restored using nvgSave() and nvgRestore().
 
 // Resets current transform to a identity matrix.
 void nvgResetTransform(NVGcontext* ctx);
@@ -419,7 +420,7 @@ NVGpaint nvgImagePattern(NVGcontext* ctx, float ox, float oy, float ex, float ey
 // Scissoring
 //
 // Scissoring allows you to clip the rendering into a rectangle. This is useful for various
-// user interface cases like rendering a text edit or a timeline. 
+// user interface cases like rendering a text edit or a timeline.
 
 // Sets the current scissor rectangle.
 // The scissor rectangle is transformed by the current transform.
@@ -474,7 +475,7 @@ void nvgArcTo(NVGcontext* ctx, float x1, float y1, float x2, float y2, float rad
 // Closes current sub-path with a line segment.
 void nvgClosePath(NVGcontext* ctx);
 
-// Sets the current sub-path winding, see NVGwinding and NVGsolidity. 
+// Sets the current sub-path winding, see NVGwinding and NVGsolidity.
 void nvgPathWinding(NVGcontext* ctx, int dir);
 
 // Creates new circle arc shaped sub-path. The arc center is at cx,cy, the arc radius is r,
@@ -491,7 +492,7 @@ void nvgRoundedRect(NVGcontext* ctx, float x, float y, float w, float h, float r
 // Creates new ellipse shaped sub-path.
 void nvgEllipse(NVGcontext* ctx, float cx, float cy, float rx, float ry);
 
-// Creates new circle shaped sub-path. 
+// Creates new circle shaped sub-path.
 void nvgCircle(NVGcontext* ctx, float cx, float cy, float r);
 
 // Fills the current path with current fill style.
@@ -554,7 +555,7 @@ void nvgFontBlur(NVGcontext* ctx, float blur);
 // Sets the letter spacing of current text style.
 void nvgTextLetterSpacing(NVGcontext* ctx, float spacing);
 
-// Sets the proportional line height of current text style. The line height is specified as multiple of font size. 
+// Sets the proportional line height of current text style. The line height is specified as multiple of font size.
 void nvgTextLineHeight(NVGcontext* ctx, float lineHeight);
 
 // Sets the text align of current text style, see NVGalign for options.


### PR DESCRIPTION
This commit implements the `nvgGlobalCompositeOperation()` function to support blending between frames. All operations defined in HTML5 canvas API are supported. Also, it is possible to create custom composite operation by calling `nvgGlobalCompositeBlendFunc()` or `nvgGlobalCompositeBlendFuncSeparate()` functions.

Example:

    # Draws a red rectangle.
    nvgBeginFrame(ctx, ...);
    nvgBeginPath(ctx);
    nvgRect(ctx, 20, 20, 75, 50);
    nvgFillColor(ctx, nvgRGBf(1, 0, 0));
    nvgFill(ctx);
    nvgEndFrame(ctx);

    # Draws a blue rectangle behind the red one.
    nvgBeginFrame(ctx, ...);
    nvgGlobalCompositeOperation(ctx, NVG_DESTINATION_OVER);
    nvgBeginPath(ctx);
    nvgRect(ctx, 50, 50, 75, 50);
    nvgFillColor(ctx, nvgRGBf(0, 0, 1));
    nvgFill(ctx);
    nvgEndFrame(ctx);
