### PR TITLE
Fixes the kerning value for freetype.

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -235,7 +235,7 @@ int fons__tt_getGlyphKernAdvance(FONSttFontImpl *font, int glyph1, int glyph2)
 {
 	FT_Vector ftKerning;
 	FT_Get_Kerning(font->font, glyph1, glyph2, FT_KERNING_DEFAULT, &ftKerning);
-	return (int)ftKerning.x;
+	return (int)((ftKerning.x + 32) >> 6);  // Round up and convert to integer
 }
 
 #else


### PR DESCRIPTION
This commit fixes issue #302 that the kerning value returned by freetype is not converted to integer properly.