### PR TITLE
Update nanovg_gl.h

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -640,7 +640,7 @@ static int glnvg__renderCreate(void* uptr)
 		"		result = color * innerCol;\n"
 		"	}\n"
 		"#ifdef EDGE_AA\n"
-		"	if (strokeAlpha < strokeThr) discard;\n"
+		"	if (strokeAlpha < strokeThr) result = vec4(0,0,0,0);\n"
 		"#endif\n"
 		"#ifdef NANOVG_GL3\n"
 		"	outColor = result;\n"


### PR DESCRIPTION
Changing from discarding the result ("discard;") to assigning the result variable with vec4(0,0,0,0) appears to drastically improve performance on iOS.

(FPS running NanoVG Demo on iPhone 5, iOS 7.0 : From 13 FPS on average to around 40 FPS)