### PR TITLE
Fallbacks to default composite operation when invalid one is specified.

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -306,7 +306,7 @@ static void glnvg__stencilFunc(GLNVGcontext* gl, GLenum func, GLint ref, GLuint 
 	if ((gl->stencilFunc != func) ||
 		(gl->stencilFuncRef != ref) ||
 		(gl->stencilFuncMask != mask)) {
-		
+
 		gl->stencilFunc = func;
 		gl->stencilFuncRef = ref;
 		gl->stencilFuncMask = mask;
@@ -339,10 +339,10 @@ static GLNVGtexture* glnvg__allocTexture(GLNVGcontext* gl)
 		}
 		tex = &gl->textures[gl->ntextures++];
 	}
-	
+
 	memset(tex, 0, sizeof(*tex));
 	tex->id = ++gl->textureId;
-	
+
 	return tex;
 }
 
@@ -522,7 +522,7 @@ static int glnvg__renderCreate(void* uptr)
 		"	gl_Position = vec4(2.0*vertex.x/viewSize.x - 1.0, 1.0 - 2.0*vertex.y/viewSize.y, 0, 1);\n"
 		"}\n";
 
-	static const char* fillFragShader = 
+	static const char* fillFragShader =
 		"#ifdef GL_ES\n"
 		"#if defined(GL_FRAGMENT_PRECISION_HIGH) || defined(NANOVG_GL3)\n"
 		" precision highp float;\n"
@@ -671,7 +671,7 @@ static int glnvg__renderCreate(void* uptr)
 #if NANOVG_GL_USE_UNIFORMBUFFER
 	// Create UBOs
 	glUniformBlockBinding(gl->shader.prog, gl->shader.loc[GLNVG_LOC_FRAG], GLNVG_FRAG_BINDING);
-	glGenBuffers(1, &gl->fragBuf); 
+	glGenBuffers(1, &gl->fragBuf);
 	glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &align);
 #endif
 	gl->fragSize = sizeof(GLNVGfragUniforms) + align - sizeof(GLNVGfragUniforms) % align;
@@ -698,7 +698,7 @@ static int glnvg__renderCreateTexture(void* uptr, int type, int w, int h, int im
 			printf("Repeat X/Y is not supported for non power-of-two textures (%d x %d)\n", w, h);
 			imageFlags &= ~(NVG_IMAGE_REPEATX | NVG_IMAGE_REPEATY);
 		}
-		// No mips. 
+		// No mips.
 		if (imageFlags & NVG_IMAGE_GENERATE_MIPMAPS) {
 			printf("Mip-maps is not support for non power-of-two textures (%d x %d)\n", w, h);
 			imageFlags &= ~NVG_IMAGE_GENERATE_MIPMAPS;
@@ -1034,7 +1034,7 @@ static void glnvg__stroke(GLNVGcontext* gl, GLNVGcall* call)
 		for (i = 0; i < npaths; i++)
 			glDrawArrays(GL_TRIANGLE_STRIP, paths[i].strokeOffset, paths[i].strokeCount);
 
-		// Clear stencil buffer.		
+		// Clear stencil buffer.
 		glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 		glnvg__stencilFunc(gl, GL_ALWAYS, 0x0, 0xff);
 		glStencilOp(GL_ZERO, GL_ZERO, GL_ZERO);
@@ -1096,11 +1096,19 @@ static GLenum glnvg_convertBlendFuncFactor(int factor)
 		return GL_ONE_MINUS_DST_ALPHA;
 	if (factor == NVG_SRC_ALPHA_SATURATE)
 		return GL_SRC_ALPHA_SATURATE;
+	return GL_INVALID_ENUM;
 }
 
 static void glnvg__blendCompositeOperation(NVGcompositeOperationState op)
 {
-	glBlendFuncSeparate(glnvg_convertBlendFuncFactor(op.srcRGB), glnvg_convertBlendFuncFactor(op.dstRGB), glnvg_convertBlendFuncFactor(op.srcAlpha), glnvg_convertBlendFuncFactor(op.dstAlpha));
+	GLenum srcRGB = glnvg_convertBlendFuncFactor(op.srcRGB);
+	GLenum dstRGB = glnvg_convertBlendFuncFactor(op.dstRGB);
+	GLenum srcAlpha = glnvg_convertBlendFuncFactor(op.srcAlpha);
+	GLenum dstAlpha = glnvg_convertBlendFuncFactor(op.dstAlpha);
+	if (srcRGB == GL_INVALID_ENUM || dstRGB == GL_INVALID_ENUM || srcAlpha == GL_INVALID_ENUM || dstAlpha == GL_INVALID_ENUM)
+		glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+	else
+		glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 static void glnvg__renderFlush(void* uptr, NVGcompositeOperationState compositeOperation)
@@ -1175,7 +1183,7 @@ static void glnvg__renderFlush(void* uptr, NVGcompositeOperationState compositeO
 		glDisableVertexAttribArray(1);
 #if defined NANOVG_GL3
 		glBindVertexArray(0);
-#endif	
+#endif
 		glDisable(GL_CULL_FACE);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 		glUseProgram(0);


### PR DESCRIPTION
This commit fixes #300 and #306 that “control may reach end of non-void function” error occurs in `glnvg_convertBlendFuncFactor()`. The function now returns `GL_INVALID_ENUM` for invalid blend factor and if that happens, `glnvg__blendCompositeOperation()` uses default source-over composite operation.