### PR TITLE
Rename nvglImageFromHandleGL2 -> nvglImageHandleGL2

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -60,7 +60,7 @@ NVGcontext* nvgCreateGL2(int flags);
 void nvgDeleteGL2(NVGcontext* ctx);
 
 int nvglCreateImageFromHandleGL2(NVGcontext* ctx, GLuint textureId, int w, int h, int flags);
-GLuint nvglImageFromHandleGL2(NVGcontext* ctx, int image);
+GLuint nvglImageHandleGL2(NVGcontext* ctx, int image);
 
 #endif
 


### PR DESCRIPTION
There was no `nvglImageFromHandleGL2` implementation, only declaration, it must have been
an error during some refactoring.

This commit renames `nvglImageFromHandleGL2` to `nvglImageHandleGL2` so now this declaration matches definition at the bottom of the file and is named similarly to other GL* functions with same name