### PR TITLE
Improves to display CJK characters with English words.

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2673,13 +2673,13 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 					rowMaxX = q.x1 - rowStartX;
 				}
 				// track last end of a word
-				if ((ptype == NVG_CHAR && type == NVG_SPACE) || type == NVG_CJK_CHAR) {
+				if (((ptype == NVG_CHAR || ptype == NVG_CJK_CHAR) && type == NVG_SPACE)  || type == NVG_CJK_CHAR) {
 					breakEnd = iter.str;
 					breakWidth = rowWidth;
 					breakMaxX = rowMaxX;
 				}
 				// track last beginning of a word
-				if ((ptype == NVG_SPACE && type == NVG_CHAR) || type == NVG_CJK_CHAR) {
+				if ((ptype == NVG_SPACE && (type == NVG_CHAR || type == NVG_CJK_CHAR)) || type == NVG_CJK_CHAR) {
 					wordStart = iter.str;
 					wordStartX = iter.x;
 					wordMinX = q.x0 - rowStartX;


### PR DESCRIPTION
This commit improves to display CJK characters mixed with English words so there is less spaces at line breaks. It seems that the previous commit didn't handle CJK characters very well. This commit should fix the issue.

Before:
![img_7246](https://cloud.githubusercontent.com/assets/76374/19553654/aa921538-96e7-11e6-88f0-020aca5db858.png)

After:
![img_7245](https://cloud.githubusercontent.com/assets/76374/19553657/ae92263c-96e7-11e6-8575-28a0b685df88.PNG)