### PR TITLE
Better support for CJK characters.

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2617,7 +2617,12 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 				type = NVG_NEWLINE;
 				break;
 			default:
-				if (iter.codepoint >= 0x4E00 && iter.codepoint <= 0x9FFF)
+				if (iter.codepoint >= 0x4E00 && iter.codepoint <= 0x9FFF ||
+					iter.codepoint >= 0x3000 && iter.codepoint <= 0x30FF ||
+					iter.codepoint >= 0xFF00 && iter.codepoint <= 0xFFEF ||
+					iter.codepoint >= 0x1100 && iter.codepoint <= 0x11FF ||
+					iter.codepoint >= 0x3130 && iter.codepoint <= 0x318F ||
+					iter.codepoint >= 0xAC00 && iter.codepoint <= 0xD7AF)
 					type = NVG_CJK_CHAR;
 				else
 					type = NVG_CHAR;


### PR DESCRIPTION
Previously, the Unicode range of the CJK chractaters only includes Chinese charactaters, Japanese Kanji, and CJK Symbols and Punctuation. The range are used by traditioanl Korean as well. This commit further includes [Hiragana](https://en.wikipedia.org/wiki/Hiragana_(Unicode_block)) and [Katakana](https://en.wikipedia.org/wiki/Katakana_(Unicode_block)) in Japanese, and [Hangul Syllables](https://en.wikipedia.org/wiki/Hangul_Syllables) and [Hangul Jamo](https://en.wikipedia.org/wiki/Hangul_Jamo_(Unicode_block)) in Korean to make CJK support more complete.

Here's a Japanese Example.

Before:
![img_7443](https://cloud.githubusercontent.com/assets/76374/19896500/7cf527da-a08f-11e6-924a-1d264382a79c.PNG)

After:
![img_7444](https://cloud.githubusercontent.com/assets/76374/19896502/8011b262-a08f-11e6-8f13-86337d706c89.PNG)
