### PR TITLE
suppresses all warnings reported by latest Xcode/AppleClang

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -263,6 +263,11 @@ static NVGcompositeOperationState nvg__compositeOperationState(int op)
 		sfactor = NVG_ONE_MINUS_DST_ALPHA;
 		dfactor = NVG_ONE_MINUS_SRC_ALPHA;
 	}
+	else
+	{
+		sfactor = NVG_ONE;
+		dfactor = NVG_ZERO;
+	}
 
 	NVGcompositeOperationState state;
 	state.srcRGB = sfactor;
@@ -461,7 +466,7 @@ NVGcolor nvgLerpRGBA(NVGcolor c0, NVGcolor c1, float u)
 {
 	int i;
 	float oneminu;
-	NVGcolor cint = {0};
+	NVGcolor cint = {{{0}}};
 
 	u = nvg__clampf(u, 0.0f, 1.0f);
 	oneminu = 1.0f - u;
@@ -2617,12 +2622,12 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 				type = NVG_NEWLINE;
 				break;
 			default:
-				if (iter.codepoint >= 0x4E00 && iter.codepoint <= 0x9FFF ||
-					iter.codepoint >= 0x3000 && iter.codepoint <= 0x30FF ||
-					iter.codepoint >= 0xFF00 && iter.codepoint <= 0xFFEF ||
-					iter.codepoint >= 0x1100 && iter.codepoint <= 0x11FF ||
-					iter.codepoint >= 0x3130 && iter.codepoint <= 0x318F ||
-					iter.codepoint >= 0xAC00 && iter.codepoint <= 0xD7AF)
+				if ((iter.codepoint >= 0x4E00 && iter.codepoint <= 0x9FFF) ||
+					(iter.codepoint >= 0x3000 && iter.codepoint <= 0x30FF) ||
+					(iter.codepoint >= 0xFF00 && iter.codepoint <= 0xFFEF) ||
+					(iter.codepoint >= 0x1100 && iter.codepoint <= 0x11FF) ||
+					(iter.codepoint >= 0x3130 && iter.codepoint <= 0x318F) ||
+					(iter.codepoint >= 0xAC00 && iter.codepoint <= 0xD7AF))
 					type = NVG_CJK_CHAR;
 				else
 					type = NVG_CHAR;


### PR DESCRIPTION
There are a bunch of warnings reported by Apple LLVM version 8.0.0 (clang-800.0.42.1).  This commit suppresses them,
<img width="314" alt="screen shot 2016-11-05 at 12 16 39 pm" src="https://cloud.githubusercontent.com/assets/1383453/20031732/856b2296-a352-11e6-88a7-bd85a095a89c.png">
