### PR TITLE
Add NVG_STB_IMAGE_IMPLEMENTATION #define

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -12,7 +12,7 @@ solution "nanovg"
 		includedirs { "src" }
 		files { "src/*.c" }
 		targetdir("build")
-		defines { "_CRT_SECURE_NO_WARNINGS" } --,"FONS_USE_FREETYPE" } Uncomment to compile with FreeType support
+		defines { "_CRT_SECURE_NO_WARNINGS", "NVG_STB_IMAGE_IMPLEMENTATION" } --,"FONS_USE_FREETYPE" } Uncomment to compile with FreeType support
 		
 		configuration "Debug"
 			defines { "DEBUG" }

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -22,9 +22,13 @@
 #include <memory.h>
 
 #include "nanovg.h"
+
 #define FONTSTASH_IMPLEMENTATION
 #include "fontstash.h"
+
+#ifdef NVG_STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_IMPLEMENTATION
+#endif
 #include "stb_image.h"
 
 #ifdef _MSC_VER


### PR DESCRIPTION
This enables the user to define the stb_image globals elsewhere, and link them in. 

Updates the `premake4.lua` config to include stb_image globals by default, mirroring the existing implementation. 