### PR TITLE
Bug fixes to compile under OS X 12.3

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -5,7 +5,7 @@ solution "nanovg"
 	location ( "build" )
 	configurations { "Debug", "Release" }
 	platforms {"native", "x64", "x32"}
-	
+
    	project "nanovg"
 		language "C"
 		kind "StaticLib"
@@ -13,7 +13,7 @@ solution "nanovg"
 		files { "src/*.c" }
 		targetdir("build")
 		defines { "_CRT_SECURE_NO_WARNINGS" } --,"FONS_USE_FREETYPE" } Uncomment to compile with FreeType support
-		
+
 		configuration "Debug"
 			defines { "DEBUG" }
 			flags { "Symbols", "ExtraWarnings"}
@@ -42,7 +42,7 @@ solution "nanovg"
 
 		configuration { "macosx" }
 			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -71,7 +71,7 @@ solution "nanovg"
 
 		configuration { "macosx" }
 			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -101,7 +101,7 @@ solution "nanovg"
 
 		configuration { "macosx" }
 			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -131,7 +131,7 @@ solution "nanovg"
 
 		configuration { "macosx" }
 			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -159,7 +159,7 @@ solution "nanovg"
 
 		configuration { "macosx" }
 			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -187,7 +187,7 @@ solution "nanovg"
 
 		configuration { "macosx" }
 			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
 			defines { "DEBUG" }
@@ -215,7 +215,7 @@ solution "nanovg"
 
 		configuration { "macosx" }
 			links { "glfw3" }
-			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo" }
+			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
 			defines { "DEBUG" }

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -113,6 +113,10 @@ enum NVGimageFlagsGL {
 #include <math.h>
 #include "nanovg.h"
 
+#ifdef __APPLE__
+#   include <OpenGL/glext.h>
+#endif
+
 enum GLNVGuniformLoc {
 	GLNVG_LOC_VIEWSIZE,
 	GLNVG_LOC_TEX,


### PR DESCRIPTION
I've discovered two bugs which prevented NanoVG from compiling under OS X 12.3 correctly.  First, the Carbon framework was missing, which prevented correct linking as they are needed by GLFW.  Second, I discovered that `nanovg_gl.h` was missing the includes for `<OpenGL/glext.h>`.  I've made both fixes, and put them as separate commits in this pull request.