### PR TITLE
Fixes how glext header is included.

### DIFF
--- a/example/example_gl2.c
+++ b/example/example_gl2.c
@@ -20,6 +20,7 @@
 #ifdef NANOVG_GLEW
 #  include <GL/glew.h>
 #endif
+#define GLFW_INCLUDE_GLEXT
 #include <GLFW/glfw3.h>
 #include "nanovg.h"
 #define NANOVG_GL2_IMPLEMENTATION

--- a/example/example_gl3.c
+++ b/example/example_gl3.c
@@ -23,6 +23,7 @@
 #ifdef __APPLE__
 #	define GLFW_INCLUDE_GLCOREARB
 #endif
+#define GLFW_INCLUDE_GLEXT
 #include <GLFW/glfw3.h>
 #include "nanovg.h"
 #define NANOVG_GL3_IMPLEMENTATION

--- a/example/example_gles2.c
+++ b/example/example_gles2.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #define GLFW_INCLUDE_ES2
+#define GLFW_INCLUDE_GLEXT
 #include <GLFW/glfw3.h>
 #include "nanovg.h"
 #define NANOVG_GLES2_IMPLEMENTATION

--- a/example/example_gles3.c
+++ b/example/example_gles3.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #define GLFW_INCLUDE_ES3
+#define GLFW_INCLUDE_GLEXT
 #include <GLFW/glfw3.h>
 #include "nanovg.h"
 #define NANOVG_GLES3_IMPLEMENTATION

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -113,10 +113,6 @@ enum NVGimageFlagsGL {
 #include <math.h>
 #include "nanovg.h"
 
-#ifdef __APPLE__
-#   include <OpenGL/glext.h>
-#endif
-
 enum GLNVGuniformLoc {
 	GLNVG_LOC_VIEWSIZE,
 	GLNVG_LOC_TEX,


### PR DESCRIPTION
This commit fixes the issue caused by #357 that nanovg failed to compile on iOS due to the wrong way of including glext header.