### PR TITLE
glfw3 -> glfw for macos

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -41,7 +41,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
+			links { "glfw" }
 			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
@@ -70,7 +70,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
+			links { "glfw" }
 			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
@@ -100,7 +100,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
+			links { "glfw" }
 			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
@@ -130,7 +130,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
+			links { "glfw" }
 			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
@@ -158,7 +158,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
+			links { "glfw" }
 			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
@@ -186,7 +186,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
+			links { "glfw" }
 			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"
@@ -214,7 +214,7 @@ solution "nanovg"
 			 defines { "NANOVG_GLEW", "_CRT_SECURE_NO_WARNINGS" }
 
 		configuration { "macosx" }
-			links { "glfw3" }
+			links { "glfw" }
 			linkoptions { "-framework OpenGL", "-framework Cocoa", "-framework IOKit", "-framework CoreVideo", "-framework Carbon" }
 
 		configuration "Debug"


### PR DESCRIPTION
I changed `glfw3` to `glfw` in premake for macos.
Because current GLFW package in homebrew locates `/usr/local/lib/libglfw.dylib`.
Pkgconfig from homebrew also say that use `-lglfw`.

```
$ cat /usr/local/lib/pkgconfig/glfw3.pc 
prefix=/usr/local/Cellar/glfw/3.2.1
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${exec_prefix}/lib

Name: GLFW
Description: A multi-platform library for OpenGL, window and input
Version: 3.2.1
URL: http://www.glfw.org/
Requires.private: 
Libs: -L${libdir} -lglfw
Libs.private:  -framework Cocoa -framework IOKit -framework CoreFoundation -framework CoreVideo
Cflags: -I${includedir}
```

This configuration is from a formula in homebrew.
https://github.com/Homebrew/homebrew-core/blob/master/Formula/glfw.rb

This formula get source and build `glfw3.pc`.
And source of this are `glfw3.pc.in`, `CMakeLists.txt` in GLFW original repository.

`glfw3.pc.in` says (https://github.com/glfw/glfw/blob/master/src/glfw3.pc.in)

```
Libs: -L${libdir} -l@GLFW_LIB_NAME@
```

`@GLFW_LIB_NAME@` is in `CMakeLists.txt` (https://github.com/glfw/glfw/blob/master/CMakeLists.txt)

```
if (BUILD_SHARED_LIBS AND UNIX)
    # On Unix-like systems, shared libraries can use the soname system.
    set(GLFW_LIB_NAME glfw)
else()
    set(GLFW_LIB_NAME glfw3)
endif()
```

So this `-lglfw` configuration is GLFW official standard.

nanovg should follow this.

Related issue: https://github.com/memononen/nanovg/issues/365