### PR TITLE
Discards fragments as early as possible.

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -334,7 +334,7 @@ static void glnvg__blendFuncSeparate(GLNVGcontext* gl, const GLNVGblend* blend)
 		(gl->blendFunc.dstRGB != blend->dstRGB) ||
 		(gl->blendFunc.srcAlpha != blend->srcAlpha) ||
 		(gl->blendFunc.dstAlpha != blend->dstAlpha)) {
-		
+
 		gl->blendFunc = *blend;
 		glBlendFuncSeparate(blend->srcRGB, blend->dstRGB, blend->srcAlpha,blend->dstAlpha);
 	}
@@ -626,6 +626,7 @@ static int glnvg__renderCreate(void* uptr)
 		"	float scissor = scissorMask(fpos);\n"
 		"#ifdef EDGE_AA\n"
 		"	float strokeAlpha = strokeMask();\n"
+		"	if (strokeAlpha < strokeThr) discard;\n"
 		"#else\n"
 		"	float strokeAlpha = 1.0;\n"
 		"#endif\n"
@@ -665,9 +666,6 @@ static int glnvg__renderCreate(void* uptr)
 		"		color *= scissor;\n"
 		"		result = color * innerCol;\n"
 		"	}\n"
-		"#ifdef EDGE_AA\n"
-		"	if (strokeAlpha < strokeThr) discard;\n"
-		"#endif\n"
 		"#ifdef NANOVG_GL3\n"
 		"	outColor = result;\n"
 		"#else\n"


### PR DESCRIPTION
This commit moves the `discard` instruction in the fragment shader to an earlier position to avoid performing calculations whose results are unused.

In my real world app, tens of thousands polygons may render per frame, and this simple change improves the FPS from 37 to 45 in a test case. It's not bad.

Before:
![screen shot 2017-07-02 at 01 04 31](https://user-images.githubusercontent.com/76374/27764103-bd0ad3cc-5ec3-11e7-9b5d-34b7bcf91cb5.png)

After:
![screen shot 2017-07-02 at 01 05 57](https://user-images.githubusercontent.com/76374/27764105-c5ebfbd8-5ec3-11e7-86f8-acec0a7d05a6.png)
