### PR TITLE
Allows to turn on/off antialias for shapes.

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -67,6 +67,7 @@ enum NVGpointFlags
 
 struct NVGstate {
 	NVGcompositeOperationState compositeOperation;
+	int shapeAntiAlias;
 	NVGpaint fill;
 	NVGpaint stroke;
 	float strokeWidth;
@@ -646,6 +647,7 @@ void nvgReset(NVGcontext* ctx)
 	nvg__setPaintColor(&state->fill, nvgRGBA(255,255,255,255));
 	nvg__setPaintColor(&state->stroke, nvgRGBA(0,0,0,255));
 	state->compositeOperation = nvg__compositeOperationState(NVG_SOURCE_OVER);
+	state->shapeAntiAlias = 1;
 	state->strokeWidth = 1.0f;
 	state->miterLimit = 10.0f;
 	state->lineCap = NVG_BUTT;
@@ -665,6 +667,12 @@ void nvgReset(NVGcontext* ctx)
 }
 
 // State setting
+void nvgShapeAntiAlias(NVGcontext* ctx, int enabled)
+{
+	NVGstate* state = nvg__getState(ctx);
+	state->shapeAntiAlias = enabled;
+}
+
 void nvgStrokeWidth(NVGcontext* ctx, float width)
 {
 	NVGstate* state = nvg__getState(ctx);
@@ -2203,7 +2211,7 @@ void nvgFill(NVGcontext* ctx)
 	int i;
 
 	nvg__flattenPaths(ctx);
-	if (ctx->params.edgeAntiAlias)
+	if (ctx->params.edgeAntiAlias && state->shapeAntiAlias)
 		nvg__expandFill(ctx, ctx->fringeWidth, NVG_MITER, 2.4f);
 	else
 		nvg__expandFill(ctx, 0.0f, NVG_MITER, 2.4f);
@@ -2248,7 +2256,7 @@ void nvgStroke(NVGcontext* ctx)
 
 	nvg__flattenPaths(ctx);
 
-	if (ctx->params.edgeAntiAlias)
+	if (ctx->params.edgeAntiAlias && state->shapeAntiAlias)
 		nvg__expandStroke(ctx, strokeWidth*0.5f + ctx->fringeWidth*0.5f, state->lineCap, state->lineJoin, state->miterLimit);
 	else
 		nvg__expandStroke(ctx, strokeWidth*0.5f, state->lineCap, state->lineJoin, state->miterLimit);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -238,6 +238,9 @@ void nvgReset(NVGcontext* ctx);
 //
 // Current render style can be saved and restored using nvgSave() and nvgRestore().
 
+// Sets whether to draw antialias for nvgStroke() and nvgFill(). It's enabled by default.
+void nvgShapeAntiAlias(NVGcontext* ctx, int enabled);
+
 // Sets current stroke style to a solid color.
 void nvgStrokeColor(NVGcontext* ctx, NVGcolor color);
 


### PR DESCRIPTION
This commit adds `nvgEnable()` and `nvgDisable()` functions for changing flags after creating the `NVGcontext` object.

Allowing changing flags is useful to get some performance gain at certain situations. For example, when applying `nvgFill()` and `nvgStroke()`  to the same path with an opaque stroke color. The antialiasing for fill operation is unnecessary because the shape edge will be covered by stroke anyway. That way, I can do something like the following code to reduce some triangle vertices from processing.

    nvgDisable(context, NVG_ANTIALIAS);
    nvgFill(context);
    nvgEnable(context, NVG_ANTIALIAS);
    nvgStroke(context);

In my real world app. I need to stroke and fill thousands of polygons per frame, and this would help improve the FPS and battery consumption a bit. Here's a simple benchmark in a test case of my app running on iPhone 6s+.

|  | Before | After|
| --- | --- | --- |
| nverts | 169,628 | 137,340 |
| FPS | 38~39 | 44~45 |