### PR TITLE
Fix example crash on 32bit platform

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -306,7 +306,7 @@ int fons__tt_getGlyphKernAdvance(FONSttFontImpl *font, int glyph1, int glyph2)
 #endif
 
 #ifndef FONS_SCRATCH_BUF_SIZE
-#	define FONS_SCRATCH_BUF_SIZE 64000
+#	define FONS_SCRATCH_BUF_SIZE 96000
 #endif
 #ifndef FONS_HASH_LUT_SIZE
 #	define FONS_HASH_LUT_SIZE 256


### PR DESCRIPTION
Fix #377 

32bit platform needs  more buffer size then 64bit platform

https://github.com/memononen/nanovg/blob/master/src/stb_truetype.h#L1617

on 32bit 
`sizeof(stbtt__active_edge) == 28`
count is 2000

on 64bit 
`sizeof(stbtt__active_edge) == 32`
count is 800
