### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -873,7 +873,8 @@ error:
 int fonsAddFont(FONScontext* stash, const char* name, const char* path)
 {
 	FILE* fp = 0;
-	int dataSize = 0, readed;
+	int dataSize = 0;
+	size_t readed;
 	unsigned char* data = NULL;
 
 	// Read in the font data.

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -390,7 +390,6 @@ void nvgCancelFrame(NVGcontext* ctx)
 
 void nvgEndFrame(NVGcontext* ctx)
 {
-	NVGstate* state = nvg__getState(ctx);
 	ctx->params.renderFlush(ctx->params.userPtr);
 	if (ctx->fontImageIdx != 0) {
 		int fontImage = ctx->fontImages[ctx->fontImageIdx];


### PR DESCRIPTION
A few minor changes to fix compiler warnings in Xcode 8.3.