### PR TITLE
Fix MSVC 2017 compiler warning

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -945,10 +945,17 @@ static int glnvg__convertPaint(GLNVGcontext* gl, GLNVGfragUniforms* frag, NVGpai
 		}
 		frag->type = NSVG_SHADER_FILLIMG;
 
+		#if NANOVG_GL_USE_UNIFORMBUFFER
 		if (tex->type == NVG_TEXTURE_RGBA)
 			frag->texType = (tex->flags & NVG_IMAGE_PREMULTIPLIED) ? 0 : 1;
 		else
 			frag->texType = 2;
+		#else
+		if (tex->type == NVG_TEXTURE_RGBA)
+			frag->texType = (tex->flags & NVG_IMAGE_PREMULTIPLIED) ? 0.0f : 1.0f;
+		else
+			frag->texType = 2.0f;
+		#endif
 //		printf("frag->texType = %d\n", frag->texType);
 	} else {
 		frag->type = NSVG_SHADER_FILLGRAD;


### PR DESCRIPTION
This fixes a compiler warning when using Visual Studio 2017 to compile. 
It warns about the conversion from int to float on the line with the ternary operator determining the textype. 
Textype can be an int or float depending on whether NANOVG_GL_USE_UNIFORMBUFFER is defined.
This takes that into account using the aforementioned define to avoid this warning.