### PR TITLE
Functions for creating shades of gray

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -450,6 +450,21 @@ NVGcolor nvgRGBAf(float r, float g, float b, float a)
 	return color;
 }
 
+NVGcolor nvgGray(unsigned char l)
+{
+	return nvgGrayf(l / 255.0f);
+}
+
+NVGcolor nvgGrayf(float l)
+{
+	NVGcolor color;
+	color.r = l;
+	color.g = l;
+	color.b = l;
+	color.a = 1.0f;
+	return color;
+}
+
 NVGcolor nvgTransRGBA(NVGcolor c, unsigned char a)
 {
 	c.a = a / 255.0f;

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -195,6 +195,13 @@ NVGcolor nvgRGBA(unsigned char r, unsigned char g, unsigned char b, unsigned cha
 NVGcolor nvgRGBAf(float r, float g, float b, float a);
 
 
+// Returns a shade of gray. Alpha will be set to 255 (1.0f).
+NVGcolor nvgGray(unsigned char l);
+
+// Returns a shade of gray. Alpha will be set to 1.0f.
+NVGcolor nvgGrayf(float l);
+
+
 // Linearly interpolates from color c0 to c1, and returns resulting color value.
 NVGcolor nvgLerpRGBA(NVGcolor c0, NVGcolor c1, float u);
 


### PR DESCRIPTION
These functions are trivial but I think they're kind of useful. We could rename them though. Perhaps `nvgGrey` or `nvgLuminance` or `nvgLumin`? This function might be too simple to justify inclusion in the library.

What do you think?