### PR TITLE
Mark devicePixelRatio unused in glnvg_renderViewport

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -991,6 +991,7 @@ static void glnvg__setUniforms(GLNVGcontext* gl, int uniformOffset, int image)
 
 static void glnvg__renderViewport(void* uptr, int width, int height, float devicePixelRatio)
 {
+	NVG_NOTUSED(devicePixelRatio);
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
 	gl->view[0] = (float)width;
 	gl->view[1] = (float)height;


### PR DESCRIPTION
This silences a warning in Clang (and GCC?) when -Wall and -Wextra is turned on.