### PR TITLE
Feature: Catmull-Rom curves

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -55,6 +55,7 @@ enum NVGcommands {
 	NVG_BEZIERTO = 2,
 	NVG_CLOSE = 3,
 	NVG_WINDING = 4,
+	NVG_CURVETO = 5
 };
 
 enum NVGpointFlags
@@ -83,6 +84,7 @@ struct NVGstate {
 	float fontBlur;
 	int textAlign;
 	int fontId;
+	int curveResolution;
 };
 typedef struct NVGstate NVGstate;
 
@@ -663,6 +665,8 @@ void nvgReset(NVGcontext* ctx)
 	state->fontBlur = 0.0f;
 	state->textAlign = NVG_ALIGN_LEFT | NVG_ALIGN_BASELINE;
 	state->fontId = 0;
+	
+	state->curveResolution = 20;
 }
 
 // State setting
@@ -1101,6 +1105,10 @@ static void nvg__appendCommands(NVGcontext* ctx, float* vals, int nvals)
 			nvgTransformPoint(&vals[i+1],&vals[i+2], state->xform, vals[i+1],vals[i+2]);
 			i += 3;
 			break;
+		case NVG_CURVETO:
+			nvgTransformPoint(&vals[i+1],&vals[i+2], state->xform, vals[i+1],vals[i+2]);
+			i += 3;
+			break;
 		case NVG_BEZIERTO:
 			nvgTransformPoint(&vals[i+1],&vals[i+2], state->xform, vals[i+1],vals[i+2]);
 			nvgTransformPoint(&vals[i+3],&vals[i+4], state->xform, vals[i+3],vals[i+4]);
@@ -1318,6 +1326,36 @@ static void nvg__tesselateBezier(NVGcontext* ctx,
 	nvg__tesselateBezier(ctx, x1234,y1234, x234,y234, x34,y34, x4,y4, level+1, type);
 }
 
+static void nvg__tesselateCurve(NVGcontext* ctx,
+								float x0, float y0,
+								float x1, float y1,
+								float x2, float y2,
+								float x3, float y3,
+								int type)
+{
+	float t,t2,t3;
+	float x,y;
+	NVGstate* state = nvg__getState(ctx);
+	
+	for (int i = 1; i <= state->curveResolution; i++){
+		
+		t 	=  (float)i / (float)(state->curveResolution);
+		t2 	= t * t;
+		t3 	= t2 * t;
+		
+		x = 0.5f * ( ( 2.0f * x1 ) +
+					( -x0 + x2 ) * t +
+					( 2.0f * x0 - 5.0f * x1 + 4 * x2 - x3 ) * t2 +
+					( -x0 + 3.0f * x1 - 3.0f * x2 + x3 ) * t3 );
+		
+		y = 0.5f * ( ( 2.0f * y1 ) +
+					( -y0 + y2 ) * t +
+					( 2.0f * y0 - 5.0f * y1 + 4 * y2 - y3 ) * t2 +
+					( -y0 + 3.0f * y1 - 3.0f * y2 + y3 ) * t3 );
+		
+		nvg__addPoint(ctx, x, y, type);
+	}
+}
 static void nvg__flattenPaths(NVGcontext* ctx)
 {
 	NVGpathCache* cache = ctx->cache;
@@ -1331,7 +1369,10 @@ static void nvg__flattenPaths(NVGcontext* ctx)
 	float* cp1;
 	float* cp2;
 	float* p;
+	float* cp3;
+	float* cp4;
 	float area;
+	static int curveCommands = 0;
 
 	if (cache->npaths > 0)
 		return;
@@ -1340,6 +1381,7 @@ static void nvg__flattenPaths(NVGcontext* ctx)
 	i = 0;
 	while (i < ctx->ncommands) {
 		int cmd = (int)ctx->commands[i];
+		if (cmd != NVG_CURVETO) curveCommands = 0;
 		switch (cmd) {
 		case NVG_MOVETO:
 			nvg__addPath(ctx);
@@ -1352,6 +1394,17 @@ static void nvg__flattenPaths(NVGcontext* ctx)
 			nvg__addPoint(ctx, p[0], p[1], NVG_PT_CORNER);
 			i += 3;
 			break;
+			case NVG_CURVETO:
+				curveCommands++;
+				p = &ctx->commands[i+1];
+				if (curveCommands > 3) {
+					cp1 = &ctx->commands[i - (3*3) + 1];
+					cp2 = &ctx->commands[i - (2*3) + 1];
+					cp3 = &ctx->commands[i - (1*3) + 1];
+					nvg__tesselateCurve(ctx, cp1[0], cp1[1], cp2[0], cp2[1], cp3[0], cp3[1], p[0], p[1], NVG_PT_CORNER);
+				}
+				i += 3;
+				break;
 		case NVG_BEZIERTO:
 			last = nvg__lastPoint(ctx);
 			if (last != NULL) {
@@ -1982,6 +2035,12 @@ void nvgQuadTo(NVGcontext* ctx, float cx, float cy, float x, float y)
         x + 2.0f/3.0f*(cx - x), y + 2.0f/3.0f*(cy - y),
         x, y };
     nvg__appendCommands(ctx, vals, NVG_COUNTOF(vals));
+}
+
+void nvgCurveTo(NVGcontext* ctx, float x, float y)
+{
+	float vals[] = { NVG_CURVETO, x, y };
+	nvg__appendCommands(ctx, vals, NVG_COUNTOF(vals));
 }
 
 void nvgArcTo(NVGcontext* ctx, float x1, float y1, float x2, float y2, float radius)

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -470,7 +470,12 @@ void nvgLineTo(NVGcontext* ctx, float x, float y);
 // Adds cubic bezier segment from last point in the path via two control points to the specified point.
 void nvgBezierTo(NVGcontext* ctx, float c1x, float c1y, float c2x, float c2y, float x, float y);
 
-// Adds a Catmul-Rom segment from the last point in the path to the specified point.
+// Adds a Catmull-Rom spline segment from the last point in the path to the specified point.
+// Catmull-Rom splines require at least four points: the first and last are control points,
+// the second and third are the beginning and end of the segment. Thus you will need to make at least
+// four calls to nvgCurveTo to see a result. Because of this, you'll typically want to add
+// both the origin and the end of your curve twice, otherwise the first and last points of the curve will
+// just be control points.
 void nvgCurveTo(NVGcontext* ctx, float x, float y);
 	
 // Adds quadratic bezier segment from last point in the path via a control point to the specified point.

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -470,6 +470,9 @@ void nvgLineTo(NVGcontext* ctx, float x, float y);
 // Adds cubic bezier segment from last point in the path via two control points to the specified point.
 void nvgBezierTo(NVGcontext* ctx, float c1x, float c1y, float c2x, float c2y, float x, float y);
 
+// Adds a Catmul-Rom segment from the last point in the path to the specified point.
+void nvgCurveTo(NVGcontext* ctx, float x, float y);
+	
 // Adds quadratic bezier segment from last point in the path via a control point to the specified point.
 void nvgQuadTo(NVGcontext* ctx, float cx, float cy, float x, float y);
 


### PR DESCRIPTION
New command nvgCurveTo to create Catmull-Rom splines. C-R splines are sometimes easier to use that beziers because they don't require you to supply control points.
Added a "curveResolution" property to NVGState to control the amount of detail that the curves are rendered with.
Added a "nvg_tesselateCurve" function that creates the points for the curve.