### PR TITLE
Make a --with-freetype option instead of having to uncomment

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -6,13 +6,22 @@ solution "nanovg"
 	configurations { "Debug", "Release" }
 	platforms {"native", "x64", "x32"}
 
+    newoption 
+    {
+        trigger = "with-freetype",
+        description = "Compile with FreeType support"
+    }
+
    	project "nanovg"
 		language "C"
 		kind "StaticLib"
 		includedirs { "src" }
 		files { "src/*.c" }
 		targetdir("build")
-		defines { "_CRT_SECURE_NO_WARNINGS" } --,"FONS_USE_FREETYPE" } Uncomment to compile with FreeType support
+		defines { "_CRT_SECURE_NO_WARNINGS" } 
+
+        configuration "with-freetype"
+            defines { "FONS_USE_FREETYPE" }
 
 		configuration "Debug"
 			defines { "DEBUG" }


### PR DESCRIPTION
In premake4.lua there was a comment about what to uncomment when needing FreeType support.
This has now been turned into a premake option that can be passed in as a command line option like this:
```
$ premake4 --with-freetype gmake
```