### PR TITLE
fix image repeation in gles2

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -644,7 +644,7 @@ static int glnvg__renderCreate(void* uptr)
 		"#ifdef NANOVG_GL3\n"
 		"		vec4 color = texture(tex, pt);\n"
 		"#else\n"
-		"		vec4 color = texture2D(tex, pt);\n"
+		"		vec4 color = texture2D(tex, fract(pt));\n"
 		"#endif\n"
 		"		if (texType == 1) color = vec4(color.xyz*color.w,color.w);"
 		"		if (texType == 2) color = vec4(color.x);"


### PR DESCRIPTION
GLESv2 does not support for texture parameter GL_REPEAT when image size is non-power-of-two, but we can use fract method to normalize the texture coord to get the image repeated.

This only take effect when the drawing area size is larger than the image size.