### PR TITLE
Forces autohint when loading glyph using FreeType.

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -204,7 +204,7 @@ int fons__tt_buildGlyphBitmap(FONSttFontImpl *font, int glyph, float size, float
 
 	ftError = FT_Set_Pixel_Sizes(font->font, 0, (FT_UInt)(size * (float)font->font->units_per_EM / (float)(font->font->ascender - font->font->descender)));
 	if (ftError) return 0;
-	ftError = FT_Load_Glyph(font->font, glyph, FT_LOAD_RENDER);
+	ftError = FT_Load_Glyph(font->font, glyph, FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT);
 	if (ftError) return 0;
 	ftError = FT_Get_Advance(font->font, glyph, FT_LOAD_NO_SCALE, &advFixed);
 	if (ftError) return 0;


### PR DESCRIPTION
This commit adds the `FT_LOAD_FORCE_AUTOHINT` parameter to `FT_Load_Glyph()` to fix wonky non-alphabetic  characters. 

I found this issue when I tried to display Google's open source Noto CJK font on an Android device. (CJK font combines Chinese, Japanese, and Korean fonts into one file because they all share a lot of Chinese and variant characters.), which is also the default font when setting Android's system language to Chinese.

This picture shows the big difference when adding `FT_LOAD_FORCE_AUTOHINT`. The font displayed on the left looks pretty bad and nothing like the font displayed by Android UI. However, the font displayed on the right looks much nature and matches the font displayed by Android UI.

![nanovg_autohint](https://user-images.githubusercontent.com/76374/43315616-17b622a2-91c9-11e8-94fa-9ef34de21c37.png)