### PR TITLE
Fixes the bug that gl may fail to draw fringes.

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -1049,12 +1049,12 @@ static void glnvg__convexFill(GLNVGcontext* gl, GLNVGcall* call)
 	glnvg__setUniforms(gl, call->uniformOffset, call->image);
 	glnvg__checkError(gl, "convex fill");
 
-	for (i = 0; i < npaths; i++)
+	for (i = 0; i < npaths; i++) {
 		glDrawArrays(GL_TRIANGLE_FAN, paths[i].fillOffset, paths[i].fillCount);
-	if (gl->flags & NVG_ANTIALIAS) {
 		// Draw fringes
-		for (i = 0; i < npaths; i++)
+		if (paths[i].strokeCount > 0) {
 			glDrawArrays(GL_TRIANGLE_STRIP, paths[i].strokeOffset, paths[i].strokeCount);
+		}
 	}
 }
 


### PR DESCRIPTION
This commit fixes the bug that `glnvg__convexFill()` tried to draw fringes depending on whether `NVG_ANTIALIAS` is set. However, #386 adds `nvgShapeAntiAlias()` for chaning anti-alias state explicitly, and `glnvg__convexFill()` would cause error If the anti-alias state is disabled.