### PR TITLE
Fix compile issue for missing { in fontstash.h

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -273,6 +273,7 @@ int fons__tt_init(FONScontext *context)
 }
 
 int fons__tt_done(FONScontext *context)
+{
 	FONS_NOTUSED(context);
 	return 1;
 }


### PR DESCRIPTION
master fails to build due to a missing `{` introduced by commit 9b27dc38947a69d2b93c9a3b6b5a707f159e9b2e.