### PR TITLE
Add NVG_DISABLE_CULL_FACE define.

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -1175,8 +1175,13 @@ static void glnvg__renderFlush(void* uptr)
 		// Setup require GL state.
 		glUseProgram(gl->shader.prog);
 
+#ifdef NVG_DISABLE_CULL_FACE
+		glDisable(GL_CULL_FACE);
+#else
 		glEnable(GL_CULL_FACE);
 		glCullFace(GL_BACK);
+#endif
+
 		glFrontFace(GL_CCW);
 		glEnable(GL_BLEND);
 		glDisable(GL_DEPTH_TEST);


### PR DESCRIPTION
The `NVG_DISABLE_CULL_FACE` will disable `GL_CULL_FACE` to allow negative scaling of sprites and paths.