### PR TITLE
Add functionality for loading specific font faces form .ttc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ NanoVG is small antialiased vector graphics rendering library for OpenGL. It has
 
 ## Screenshot
 
-![screenshot of some text rendered witht the sample program](/example/screenshot-01.png?raw=true)
+![screenshot of some text rendered with the sample program](/example/screenshot-01.png?raw=true)
 
 Usage
 =====

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -418,7 +418,7 @@ struct FONSstate
 typedef struct FONSstate FONSstate;
 
 struct FONSatlasNode {
-    short x, y, width;
+	short x, y, width;
 };
 typedef struct FONSatlasNode FONSatlasNode;
 
@@ -509,11 +509,11 @@ static unsigned int fons__decutf8(unsigned int* state, unsigned int* codep, unsi
 		12,12,12,12,12,12,12,24,12,12,12,12, 12,24,12,12,12,12,12,12,12,24,12,12,
 		12,12,12,12,12,12,12,36,12,36,12,12, 12,36,12,12,12,12,12,36,12,36,12,12,
 		12,36,12,12,12,12,12,12,12,12,12,12,
-    };
+	};
 
 	unsigned int type = utf8d[byte];
 
-    *codep = (*state != FONS_UTF8_ACCEPT) ?
+	*codep = (*state != FONS_UTF8_ACCEPT) ?
 		(byte & 0x3fu) | (*codep << 6) :
 		(0xff >> type) & (byte);
 

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -337,7 +337,7 @@ error:
 
 NVGparams* nvgInternalParams(NVGcontext* ctx)
 {
-    return &ctx->params;
+	return &ctx->params;
 }
 
 void nvgDeleteInternal(NVGcontext* ctx)
@@ -1989,13 +1989,13 @@ void nvgBezierTo(NVGcontext* ctx, float c1x, float c1y, float c2x, float c2y, fl
 
 void nvgQuadTo(NVGcontext* ctx, float cx, float cy, float x, float y)
 {
-    float x0 = ctx->commandx;
-    float y0 = ctx->commandy;
-    float vals[] = { NVG_BEZIERTO,
-        x0 + 2.0f/3.0f*(cx - x0), y0 + 2.0f/3.0f*(cy - y0),
-        x + 2.0f/3.0f*(cx - x), y + 2.0f/3.0f*(cy - y),
-        x, y };
-    nvg__appendCommands(ctx, vals, NVG_COUNTOF(vals));
+	float x0 = ctx->commandx;
+	float y0 = ctx->commandy;
+	float vals[] = { NVG_BEZIERTO,
+		x0 + 2.0f/3.0f*(cx - x0), y0 + 2.0f/3.0f*(cy - y0),
+		x + 2.0f/3.0f*(cx - x), y + 2.0f/3.0f*(cy - y),
+		x, y };
+	nvg__appendCommands(ctx, vals, NVG_COUNTOF(vals));
 }
 
 void nvgArcTo(NVGcontext* ctx, float x1, float y1, float x2, float y2, float radius)

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2289,12 +2289,22 @@ void nvgStroke(NVGcontext* ctx)
 // Add fonts
 int nvgCreateFont(NVGcontext* ctx, const char* name, const char* path)
 {
-	return fonsAddFont(ctx->fs, name, path);
+	return nvgCreateFontFace(ctx, name, path, 0);
+}
+
+int nvgCreateFontFace(NVGcontext* ctx, const char* name, const char* path, int faceIdx)
+{
+	return fonsAddFont(ctx->fs, name, path, faceIdx);
 }
 
 int nvgCreateFontMem(NVGcontext* ctx, const char* name, unsigned char* data, int ndata, int freeData)
 {
-	return fonsAddFontMem(ctx->fs, name, data, ndata, freeData);
+	return nvgCreateFontFaceMem(ctx, name, data, ndata, 0, freeData);
+}
+
+int nvgCreateFontFaceMem(NVGcontext* ctx, const char* name, unsigned char* data, int ndata, int faceIdx, int freeData)
+{
+	return fonsAddFontMem(ctx->fs, name, data, ndata, faceIdx, freeData);
 }
 
 int nvgFindFont(NVGcontext* ctx, const char* name)

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -136,7 +136,7 @@ struct NVGtextRow {
 typedef struct NVGtextRow NVGtextRow;
 
 enum NVGimageFlags {
-    NVG_IMAGE_GENERATE_MIPMAPS	= 1<<0,     // Generate mipmaps during creation of the image.
+	NVG_IMAGE_GENERATE_MIPMAPS	= 1<<0,		// Generate mipmaps during creation of the image.
 	NVG_IMAGE_REPEATX			= 1<<1,		// Repeat image in X direction.
 	NVG_IMAGE_REPEATY			= 1<<2,		// Repeat image in Y direction.
 	NVG_IMAGE_FLIPY				= 1<<3,		// Flips (inverses) image in Y direction when rendered.

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -546,9 +546,17 @@ void nvgStroke(NVGcontext* ctx);
 // Returns handle to the font.
 int nvgCreateFont(NVGcontext* ctx, const char* name, const char* filename);
 
+// Creates font by loading it from the disk from specified file name, loading a specific face by index.
+// Returns handle to the font.
+int nvgCreateFontFace(NVGcontext* ctx, const char* name, const char* filename, int faceIdx);
+
 // Creates font by loading it from the specified memory chunk.
 // Returns handle to the font.
 int nvgCreateFontMem(NVGcontext* ctx, const char* name, unsigned char* data, int ndata, int freeData);
+
+// Creates font by loading it from the specified memory chunk, loading a specific face by index.
+// Returns handle to the font.
+int nvgCreateFontFaceMem(NVGcontext* ctx, const char* name, unsigned char* data, int ndata, int faceIdx, int freeData);
 
 // Finds a loaded font of specified name, and returns handle to it, or -1 if the font is not found.
 int nvgFindFont(NVGcontext* ctx, const char* name);


### PR DESCRIPTION
This pull request adds two font loading functions that allow loading faces from .ttc files (on disk or in memory) given an index for the face. This involves changes through into fontstash.h to update font loading to support this. This should support this functionality for either stb_true_type or freetype.

There are also some minor cosmetic fixes in the other two commits.