### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Usage
 
 The NanoVG API is modeled loosely on HTML5 canvas API. If you know canvas, you're up to speed with NanoVG in no time.
 
+## Building nanovg - Using vcpkg
+
+You can download and install nanovg using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install nanovg
+
+The nanovg port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Creating drawing context
 
 The drawing context is created using platform specific constructor function. If you're using the OpenGL 2.0 back-end the context is created as follows:


### PR DESCRIPTION
Nanovg is available as a port in vcpkg, a C++ library manager that simplifies installation for nanovg and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build nanovg, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.