### PR TITLE
Basic support for .ttc fonts — load first font instead of failing

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -284,7 +284,9 @@ int fons__tt_loadFont(FONScontext *context, FONSttFontImpl *font, unsigned char 
 	FONS_NOTUSED(dataSize);
 
 	font->font.userdata = context;
-	stbError = stbtt_InitFont(&font->font, data, 0);
+	
+	int offset = stbtt_GetFontOffsetForIndex(data, 0);
+	stbError = stbtt_InitFont(&font->font, data, offset);
 	return stbError;
 }
 


### PR DESCRIPTION
stb_truetype supports .ttc fonts, but you have to pass in an offset to say which font in the collection you want. Before, we would always pass in 0, which isn't a valid offset, causing .ttc fonts to fail to load. Now, we pass in the offset of the first font in the collection.

stbtt_GetFontOffsetForIndex is defined to return 0 if the font is a normal .ttf, so in that case the behaviour is unchanged.