### PR TITLE
Sanitize demo.c and perf.c not to introduce a dependency on OpenGL or GLFW headers needlessly.

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -5,7 +5,9 @@
 #ifdef NANOVG_GLEW
 #  include <GL/glew.h>
 #endif
-#include <GLFW/glfw3.h>
+#ifdef DEMO_OPENGL
+#  include <GLFW/glfw3.h>
+#endif
 #include "nanovg.h"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
@@ -1212,6 +1214,7 @@ static void flipHorizontal(unsigned char* image, int w, int h, int stride)
 
 void saveScreenShot(int w, int h, int premult, const char* name)
 {
+#ifdef DEMO_OPENGL
 	unsigned char* image = (unsigned char*)malloc(w*h*4);
 	if (image == NULL)
 		return;
@@ -1223,4 +1226,5 @@ void saveScreenShot(int w, int h, int premult, const char* name)
 	flipHorizontal(image, w, h, w*4);
  	stbi_write_png(name, w, h, 4, image, w*4);
  	free(image);
+#endif
 }

--- a/example/perf.c
+++ b/example/perf.c
@@ -5,7 +5,9 @@
 #ifdef NANOVG_GLEW
 #  include <GL/glew.h>
 #endif
-#include <GLFW/glfw3.h>
+#ifdef DEMO_OPENGL
+#  include <GLFW/glfw3.h>
+#endif
 #include "nanovg.h"
 
 #ifdef _MSC_VER
@@ -51,6 +53,7 @@ int stopGPUTimer(GPUtimer* timer, float* times, int maxTimes)
 {
 	NVG_NOTUSED(times);
 	NVG_NOTUSED(maxTimes);
+#ifdef DEMO_OPENGL
 	GLint available = 1;
 	int n = 0;
 	if (!timer->supported)
@@ -71,6 +74,9 @@ int stopGPUTimer(GPUtimer* timer, float* times, int maxTimes)
 		}
 	}
 	return n;
+#else
+	return 0;
+#endif
 }
 
 

--- a/premake4.lua
+++ b/premake4.lua
@@ -26,6 +26,7 @@ solution "nanovg"
 
 		kind "ConsoleApp"
 		language "C"
+		defines { "DEMO_OPENGL" }
 		files { "example/example_gl2.c", "example/demo.c", "example/perf.c" }
 		includedirs { "src", "example" }
 		targetdir("build")
@@ -55,6 +56,7 @@ solution "nanovg"
 	project "example_gl3"
 		kind "ConsoleApp"
 		language "C"
+		defines { "DEMO_OPENGL" }
 		files { "example/example_gl3.c", "example/demo.c", "example/perf.c" }
 		includedirs { "src", "example" }
 		targetdir("build")
@@ -84,7 +86,7 @@ solution "nanovg"
 	project "example_gl2_msaa"
 		kind "ConsoleApp"
 		language "C"
-		defines { "DEMO_MSAA" }
+		defines { "DEMO_OPENGL", "DEMO_MSAA" }
 		files { "example/example_gl2.c", "example/demo.c", "example/perf.c" }
 		includedirs { "src", "example" }
 		targetdir("build")
@@ -114,7 +116,7 @@ solution "nanovg"
 	project "example_gl3_msaa"
 		kind "ConsoleApp"
 		language "C"
-		defines { "DEMO_MSAA" }
+		defines { "DEMO_OPENGL", "DEMO_MSAA" }
 		files { "example/example_gl3.c", "example/demo.c", "example/perf.c" }
 		includedirs { "src", "example" }
 		targetdir("build")
@@ -144,6 +146,7 @@ solution "nanovg"
 	project "example_fbo"
 		kind "ConsoleApp"
 		language "C"
+		defines { "DEMO_OPENGL" }
 		files { "example/example_fbo.c", "example/perf.c" }
 		includedirs { "src", "example" }
 		targetdir("build")
@@ -172,6 +175,7 @@ solution "nanovg"
 	project "example_gles2"
 		kind "ConsoleApp"
 		language "C"
+		defines { "DEMO_OPENGL" }
 		files { "example/example_gles2.c", "example/demo.c", "example/perf.c" }
 		includedirs { "src", "example" }
 		targetdir("build")
@@ -200,6 +204,7 @@ solution "nanovg"
 	project "example_gles3"
 		kind "ConsoleApp"
 		language "C"
+		defines { "DEMO_OPENGL" }
 		files { "example/example_gles3.c", "example/demo.c", "example/perf.c" }
 		includedirs { "src", "example" }
 		targetdir("build")


### PR DESCRIPTION
Sanitize demo.c and perf.c so they can be used to make a demo app with any backend, without introducing a dependency on OpenGL or GLFW headers needlessly.