### PR TITLE
Fixes the issue that font size is inconsistent.

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -194,7 +194,7 @@ void fons__tt_getFontVMetrics(FONSttFontImpl *font, int *ascent, int *descent, i
 
 float fons__tt_getPixelHeightScale(FONSttFontImpl *font, float size)
 {
-	return size / (font->font->ascender - font->font->descender);
+	return size / font->font->units_per_EM;
 }
 
 int fons__tt_getGlyphIndex(FONSttFontImpl *font, int codepoint)
@@ -210,7 +210,7 @@ int fons__tt_buildGlyphBitmap(FONSttFontImpl *font, int glyph, float size, float
 	FT_Fixed advFixed;
 	FONS_NOTUSED(scale);
 
-	ftError = FT_Set_Pixel_Sizes(font->font, 0, (FT_UInt)(size * (float)font->font->units_per_EM / (float)(font->font->ascender - font->font->descender)));
+	ftError = FT_Set_Pixel_Sizes(font->font, 0, size);
 	if (ftError) return 0;
 	ftError = FT_Load_Glyph(font->font, glyph, FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT);
 	if (ftError) return 0;
@@ -295,7 +295,7 @@ void fons__tt_getFontVMetrics(FONSttFontImpl *font, int *ascent, int *descent, i
 
 float fons__tt_getPixelHeightScale(FONSttFontImpl *font, float size)
 {
-	return stbtt_ScaleForPixelHeight(&font->font, size);
+	return stbtt_ScaleForMappingEmToPixels(&font->font, size);
 }
 
 int fons__tt_getGlyphIndex(FONSttFontImpl *font, int codepoint)


### PR DESCRIPTION
This commit fixes the issue that font size is inconsistent between different font files. `stb_truetype.h` is also updated to the latest version to support additional font types such as OpenType fonts.

The inconsistent font size issue was mentioned at #382 and I experienced the same issue for my app a long time ago. I always see different font sizes (even if they set to the same value) with different font files on screen.

Here is the current NanoVG's implementation result compared to Apple's Pages app. There are three font files used for English / Chinese / Thai, respectively.

 * English: Gotham Round (TTF)
 * Chinese: Noto Sans CJK (OTF)
 * Thai: Noto San Thai (TTF)

![NanoVG Font Test 1](https://user-images.githubusercontent.com/76374/74138708-0affd880-4c2d-11ea-831e-d5dcce0c23f6.png)

The Pages app shows bolder font for some reason, but that doesn't matter. Here we can see the stb backend can't render OpenType fonts. That's because NanoVG uses a very old `stb_truetype.h` by now. After updating the header file to the latest version. Both `stb` and `FreeType` backends show the same result.

![NanoVG Font Test 2](https://user-images.githubusercontent.com/76374/74139521-7dbd8380-4c2e-11ea-8b7d-2a2b6d7496ab.png)

However, the font sizes are still inconsistent. Only English character's font size is correct. After some investigation of `fontstash.h`. I found that this was caused by `fons__tt_getPixelWidthScale()`. The ascender and descender are used to calculate the font height and thus the scale. However, for some reason, the calculated font height diffs a lot in different font files. After some experiments, I managed to fix it by calculating the scale using `unit per em`. Now the font size is consistent across different font files.

![NanoVG Font Test 3](https://user-images.githubusercontent.com/76374/74140110-6e8b0580-4c2f-11ea-808c-fb481b951ea5.png)
