### PR TITLE
Support for resetting fallback fonts.

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -797,6 +797,17 @@ int fonsAddFallbackFont(FONScontext* stash, int base, int fallback)
 	return 0;
 }
 
+void fonsResetFallbackFont(FONScontext* stash, int base)
+{
+	int i;
+
+	FONSfont* baseFont = stash->fonts[base];
+	baseFont->nfallbacks = 0;
+	baseFont->nglyphs = 0;
+	for (i = 0; i < FONS_HASH_LUT_SIZE; i++)
+		baseFont->lut[i] = -1;
+}
+
 void fonsSetSize(FONScontext* stash, float size)
 {
 	fons__getState(stash)->size = size;

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2325,6 +2325,16 @@ int nvgAddFallbackFont(NVGcontext* ctx, const char* baseFont, const char* fallba
 	return nvgAddFallbackFontId(ctx, nvgFindFont(ctx, baseFont), nvgFindFont(ctx, fallbackFont));
 }
 
+void nvgResetFallbackFontsId(NVGcontext* ctx, int baseFont)
+{
+	fonsResetFallbackFont(ctx->fs, baseFont);
+}
+
+void nvgResetFallbackFonts(NVGcontext* ctx, const char* baseFont)
+{
+	nvgResetFallbackFontsId(ctx, nvgFindFont(ctx, baseFont));
+}
+
 // State setting
 void nvgFontSize(NVGcontext* ctx, float size)
 {

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -565,6 +565,12 @@ int nvgAddFallbackFontId(NVGcontext* ctx, int baseFont, int fallbackFont);
 // Adds a fallback font by name.
 int nvgAddFallbackFont(NVGcontext* ctx, const char* baseFont, const char* fallbackFont);
 
+// Resets fallback fonts by handle.
+void nvgResetFallbackFontsId(NVGcontext* ctx, int baseFont);
+
+// Resets fallback fonts by name.
+void nvgResetFallbackFonts(NVGcontext* ctx, const char* baseFont);
+
 // Sets the font size of current text style.
 void nvgFontSize(NVGcontext* ctx, float size);
 


### PR DESCRIPTION
This commit adds `nvgResetFallbackFontsId()` and `nvgResetFallbackFonts()` functions for resetting fallback fonts. This would be very useful for improved CJK font support.

For example. If we always use an English-only font as the base font. We need to make sure the first fallback font is a Japanese font for Japanese articles or a Chinese font for Chinese articles. Right now there is no way to reset fallback fonts and thus the first assigned CJK font will be used across different languages.