### PR TITLE
Fixes the issue that line gap may ruin the text layout.

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -953,10 +953,11 @@ int fonsAddFontMem(FONScontext* stash, const char* name, unsigned char* data, in
 	// Store normalized line height. The real line height is got
 	// by multiplying the lineh by font size.
 	fons__tt_getFontVMetrics( &font->font, &ascent, &descent, &lineGap);
+	ascent += lineGap;
 	fh = ascent - descent;
 	font->ascender = (float)ascent / (float)fh;
 	font->descender = (float)descent / (float)fh;
-	font->lineh = (float)(fh + lineGap) / (float)fh;
+	font->lineh = font->ascender - font->descender;
 
 	return idx;
 


### PR DESCRIPTION
iOS uses the `Hiragino Sans` font as the default Japanese font. However, this font abuses the `line gap` property like many fonts.

 * Adobe fonts usually treat `line gap` as the `line height`.
 * Most other western fonts sets `line gap` to 200.

Back to the `Hiragino` font. The font family always sets `line gap` to 500 no matter what while the `font height (ascent - descent)` is only 1000. Which causes the spaces between lines are super big. 

<img width="198" alt="Screen Shot 2020-02-28 at 5 31 10 PM" src="https://user-images.githubusercontent.com/76374/75535457-256ceb00-5a50-11ea-8126-5282fcd304d1.png">

As mentioned here https://stackoverflow.com/questions/5414730/custom-installed-font-not-displayed-correctly-in-uilabel, Apple ignores the `line gap` property since iOS 7, and a workaround to fix this issue is to add the `line gap` to the `ascent` and we'll be fine to ignore the `line gap` property. Now the result looks much normal.

<img width="198" alt="Screen Shot 2020-02-28 at 5 30 27 PM" src="https://user-images.githubusercontent.com/76374/75535080-0c643a00-5a50-11ea-8b60-9619452b6408.png">


This change doesn't affect the alignment, either.

![linegap](https://user-images.githubusercontent.com/76374/75532915-6d3f4280-5a4f-11ea-97c6-96c4c6c25b2a.png)