### PR TITLE
Fixes demo’s font sizes.

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -98,7 +98,7 @@ void drawWindow(NVGcontext* vg, const char* title, float x, float y, float w, fl
 	nvgStrokeColor(vg, nvgRGBA(0,0,0,32));
 	nvgStroke(vg);
 
-	nvgFontSize(vg, 18.0f);
+	nvgFontSize(vg, 15.0f);
 	nvgFontFace(vg, "sans-bold");
 	nvgTextAlign(vg,NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
 
@@ -137,7 +137,7 @@ void drawSearchBox(NVGcontext* vg, const char* text, float x, float y, float w, 
 	nvgTextAlign(vg,NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
 	nvgText(vg, x+h*0.55f, y+h*0.55f, cpToUTF8(ICON_SEARCH,icon), NULL);
 
-	nvgFontSize(vg, 20.0f);
+	nvgFontSize(vg, 17.0f);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGBA(255,255,255,32));
 
@@ -168,7 +168,7 @@ void drawDropDown(NVGcontext* vg, const char* text, float x, float y, float w, f
 	nvgStrokeColor(vg, nvgRGBA(0,0,0,48));
 	nvgStroke(vg);
 
-	nvgFontSize(vg, 20.0f);
+	nvgFontSize(vg, 17.0f);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGBA(255,255,255,160));
 	nvgTextAlign(vg,NVG_ALIGN_LEFT|NVG_ALIGN_MIDDLE);
@@ -185,7 +185,7 @@ void drawLabel(NVGcontext* vg, const char* text, float x, float y, float w, floa
 {
 	NVG_NOTUSED(w);
 
-	nvgFontSize(vg, 18.0f);
+	nvgFontSize(vg, 15.0f);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGBA(255,255,255,128));
 
@@ -214,7 +214,7 @@ void drawEditBox(NVGcontext* vg, const char* text, float x, float y, float w, fl
 
 	drawEditBoxBase(vg, x,y, w,h);
 
-	nvgFontSize(vg, 20.0f);
+	nvgFontSize(vg, 17.0f);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGBA(255,255,255,64));
 	nvgTextAlign(vg,NVG_ALIGN_LEFT|NVG_ALIGN_MIDDLE);
@@ -230,13 +230,13 @@ void drawEditBoxNum(NVGcontext* vg,
 
 	uw = nvgTextBounds(vg, 0,0, units, NULL, NULL);
 
-	nvgFontSize(vg, 18.0f);
+	nvgFontSize(vg, 15.0f);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGBA(255,255,255,64));
 	nvgTextAlign(vg,NVG_ALIGN_RIGHT|NVG_ALIGN_MIDDLE);
 	nvgText(vg, x+w-h*0.3f,y+h*0.5f,units, NULL);
 
-	nvgFontSize(vg, 20.0f);
+	nvgFontSize(vg, 17.0f);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGBA(255,255,255,128));
 	nvgTextAlign(vg,NVG_ALIGN_RIGHT|NVG_ALIGN_MIDDLE);
@@ -249,7 +249,7 @@ void drawCheckBox(NVGcontext* vg, const char* text, float x, float y, float w, f
 	char icon[8];
 	NVG_NOTUSED(w);
 
-	nvgFontSize(vg, 18.0f);
+	nvgFontSize(vg, 15.0f);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGBA(255,255,255,160));
 
@@ -262,7 +262,7 @@ void drawCheckBox(NVGcontext* vg, const char* text, float x, float y, float w, f
 	nvgFillPaint(vg, bg);
 	nvgFill(vg);
 
-	nvgFontSize(vg, 40);
+	nvgFontSize(vg, 33);
 	nvgFontFace(vg, "icons");
 	nvgFillColor(vg, nvgRGBA(255,255,255,128));
 	nvgTextAlign(vg,NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
@@ -291,7 +291,7 @@ void drawButton(NVGcontext* vg, int preicon, const char* text, float x, float y,
 	nvgStrokeColor(vg, nvgRGBA(0,0,0,48));
 	nvgStroke(vg);
 
-	nvgFontSize(vg, 20.0f);
+	nvgFontSize(vg, 17.0f);
 	nvgFontFace(vg, "sans-bold");
 	tw = nvgTextBounds(vg, 0,0, text, NULL, NULL);
 	if (preicon != 0) {
@@ -309,7 +309,7 @@ void drawButton(NVGcontext* vg, int preicon, const char* text, float x, float y,
 		nvgText(vg, x+w*0.5f-tw*0.5f-iw*0.75f, y+h*0.5f, cpToUTF8(preicon,icon), NULL);
 	}
 
-	nvgFontSize(vg, 20.0f);
+	nvgFontSize(vg, 17.0f);
 	nvgFontFace(vg, "sans-bold");
 	nvgTextAlign(vg,NVG_ALIGN_LEFT|NVG_ALIGN_MIDDLE);
 	nvgFillColor(vg, nvgRGBA(0,0,0,160));
@@ -874,7 +874,7 @@ void drawParagraph(NVGcontext* vg, float x, float y, float width, float height, 
 
 	nvgSave(vg);
 
-	nvgFontSize(vg, 18.0f);
+	nvgFontSize(vg, 15.0f);
 	nvgFontFace(vg, "sans");
 	nvgTextAlign(vg, NVG_ALIGN_LEFT|NVG_ALIGN_TOP);
 	nvgTextMetrics(vg, NULL, NULL, &lineh);
@@ -928,7 +928,7 @@ void drawParagraph(NVGcontext* vg, float x, float y, float width, float height, 
 	if (gutter) {
 		char txt[16];
 		snprintf(txt, sizeof(txt), "%d", gutter);
-		nvgFontSize(vg, 13.0f);
+		nvgFontSize(vg, 12.0f);
 		nvgTextAlign(vg, NVG_ALIGN_RIGHT|NVG_ALIGN_MIDDLE);
 
 		nvgTextBounds(vg, gx,gy, txt, NULL, bounds);
@@ -944,7 +944,7 @@ void drawParagraph(NVGcontext* vg, float x, float y, float width, float height, 
 
 	y += 20.0f;
 
-	nvgFontSize(vg, 13.0f);
+	nvgFontSize(vg, 11.0f);
 	nvgTextAlign(vg, NVG_ALIGN_LEFT|NVG_ALIGN_TOP);
 	nvgTextLineHeight(vg, 1.2f);
 


### PR DESCRIPTION
This commit fixes the demo’s font sizes for the changes in #558, which makes the rendered font size matches what you saw on other native apps. The demo used bigger font sizes than they actually were. This commit deduces the font sizes to match the original demo’s look.

<img width="1112" alt="Screen Shot 2020-02-28 at 6 22 05 PM" src="https://user-images.githubusercontent.com/76374/75541036-29047000-5a58-11ea-92ea-2f71463d0af5.png">
