### PR TITLE
Added cmake build file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+set(PROJECT_NAME nanovg)
+
+project(${PROJECT_NAME})
+
+set(SRC_DIR "./src")
+file(GLOB SRCS ${SRC_DIR}/*.c)
+file(GLOB HDRS ${SRC_DIR}/*.h)
+
+add_library(${PROJECT_NAME} ${SRCS})
+
+
+install(TARGETS ${PROJECT_NAME}
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include/${PROJECT_NAME}
+)
+
+install(FILES ${HDRS} DESTINATION include/${PROJECT_NAME}/)


### PR DESCRIPTION
Added a simple cmake build file that can be used to build and install nanovg static library. And then it can be linked using -lnanovg and header files can be included simply - like #include <nanovg/nanovg.h>. Though it might be useful for others as well.