### PR TITLE
Bind a dummy texture in setUniforms when compiling with emscripten

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -704,13 +704,13 @@ static int glnvg__renderCreate(void* uptr)
 #endif
 	gl->fragSize = sizeof(GLNVGfragUniforms) + align - sizeof(GLNVGfragUniforms) % align;
 
+#ifdef __EMSCRIPTEN__
+	gl->dummyTex = glnvg__renderCreateTexture(&gl, NVG_TEXTURE_ALPHA, 1, 1, 0, NULL);
+#endif
+
 	glnvg__checkError(gl, "create done");
 
 	glFinish();
-
-#ifdef __EMSCRIPTEN__
-	gl->dummyTex = 0;
-#endif
 
 	return 1;
 }
@@ -994,9 +994,6 @@ static void glnvg__setUniforms(GLNVGcontext* gl, int uniformOffset, int image)
 		glnvg__checkError(gl, "tex paint tex");
 	} else {
 #ifdef __EMSCRIPTEN__
-		if(gl->dummyTex == 0) {
-			gl->dummyTex = glnvg__renderCreateTexture(&gl, NVG_TEXTURE_ALPHA, 2, 2, 0, NULL);
-		}
 		GLNVGtexture* tex = glnvg__findTexture(gl, gl->dummyTex);
 		glnvg__bindTexture(gl, tex->tex);
 #else

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -269,9 +269,7 @@ struct GLNVGcontext {
 	GLNVGblend blendFunc;
 	#endif
 
-#ifdef __EMSCRIPTEN__
 	int dummyTex;
-#endif
 };
 typedef struct GLNVGcontext GLNVGcontext;
 
@@ -504,6 +502,8 @@ static void glnvg__getUniforms(GLNVGshader* shader)
 #endif
 }
 
+static int glnvg__renderCreateTexture(void* uptr, int type, int w, int h, int imageFlags, const unsigned char* data);
+
 static int glnvg__renderCreate(void* uptr)
 {
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
@@ -704,9 +704,9 @@ static int glnvg__renderCreate(void* uptr)
 #endif
 	gl->fragSize = sizeof(GLNVGfragUniforms) + align - sizeof(GLNVGfragUniforms) % align;
 
-#ifdef __EMSCRIPTEN__
-	gl->dummyTex = glnvg__renderCreateTexture(&gl, NVG_TEXTURE_ALPHA, 1, 1, 0, NULL);
-#endif
+	// Some platforms does not allow to have samples to unset textures.
+	// Create empty one which is bound when there's no texture specified.
+	gl->dummyTex = glnvg__renderCreateTexture(gl, NVG_TEXTURE_ALPHA, 1, 1, 0, NULL);
 
 	glnvg__checkError(gl, "create done");
 
@@ -981,6 +981,7 @@ static GLNVGfragUniforms* nvg__fragUniformPtr(GLNVGcontext* gl, int i);
 
 static void glnvg__setUniforms(GLNVGcontext* gl, int uniformOffset, int image)
 {
+	GLNVGtexture* tex = NULL;
 #if NANOVG_GL_USE_UNIFORMBUFFER
 	glBindBufferRange(GL_UNIFORM_BUFFER, GLNVG_FRAG_BINDING, gl->fragBuf, uniformOffset, sizeof(GLNVGfragUniforms));
 #else
@@ -989,17 +990,14 @@ static void glnvg__setUniforms(GLNVGcontext* gl, int uniformOffset, int image)
 #endif
 
 	if (image != 0) {
-		GLNVGtexture* tex = glnvg__findTexture(gl, image);
-		glnvg__bindTexture(gl, tex != NULL ? tex->tex : 0);
-		glnvg__checkError(gl, "tex paint tex");
-	} else {
-#ifdef __EMSCRIPTEN__
-		GLNVGtexture* tex = glnvg__findTexture(gl, gl->dummyTex);
-		glnvg__bindTexture(gl, tex->tex);
-#else
-		glnvg__bindTexture(gl, 0);
-#endif
+		tex = glnvg__findTexture(gl, image);
 	}
+	// If no image is set, use empty texture
+	if (tex == NULL) {
+		tex = glnvg__findTexture(gl, gl->dummyTex);
+	}
+	glnvg__bindTexture(gl, tex != NULL ? tex->tex : 0);
+	glnvg__checkError(gl, "tex paint tex");
 }
 
 static void glnvg__renderViewport(void* uptr, float width, float height, float devicePixelRatio)

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -268,6 +268,10 @@ struct GLNVGcontext {
 	GLuint stencilFuncMask;
 	GLNVGblend blendFunc;
 	#endif
+
+#ifdef __EMSCRIPTEN__
+	int dummyTex;
+#endif
 };
 typedef struct GLNVGcontext GLNVGcontext;
 
@@ -704,6 +708,10 @@ static int glnvg__renderCreate(void* uptr)
 
 	glFinish();
 
+#ifdef __EMSCRIPTEN__
+	gl->dummyTex = 0;
+#endif
+
 	return 1;
 }
 
@@ -985,7 +993,15 @@ static void glnvg__setUniforms(GLNVGcontext* gl, int uniformOffset, int image)
 		glnvg__bindTexture(gl, tex != NULL ? tex->tex : 0);
 		glnvg__checkError(gl, "tex paint tex");
 	} else {
+#ifdef __EMSCRIPTEN__
+		if(gl->dummyTex == 0) {
+			gl->dummyTex = glnvg__renderCreateTexture(&gl, NVG_TEXTURE_ALPHA, 2, 2, 0, NULL);
+		}
+		GLNVGtexture* tex = glnvg__findTexture(gl, gl->dummyTex);
+		glnvg__bindTexture(gl, tex->tex);
+#else
 		glnvg__bindTexture(gl, 0);
+#endif
 	}
 }
 


### PR DESCRIPTION
fixes the WebGL error "RENDER WARNING: there is no texture bound to the unit 0"" in Chrome

note: previous PR worked with nanovg example, but not with iPlug2, where webgl context is initially hidden. In this PR i create the dummy texture on first use which seems to work in both cases

see discussion https://github.com/memononen/nanovg/issues/398#issuecomment-437004233