### PR TITLE
Fixes incorrect glyph width.

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -70,6 +70,7 @@ struct FONSquad
 {
 	float x0,y0,s0,t0;
 	float x1,y1,s1,t1;
+	float xadv;
 };
 typedef struct FONSquad FONSquad;
 
@@ -1232,6 +1233,7 @@ static void fons__getQuad(FONScontext* stash, FONSfont* font,
 		q->y0 = ry;
 		q->x1 = rx + x1 - x0;
 		q->y1 = ry + y1 - y0;
+		q->xadv = glyph->xadv / 10.0f;
 
 		q->s0 = x0 * stash->itw;
 		q->t0 = y0 * stash->ith;
@@ -1245,6 +1247,7 @@ static void fons__getQuad(FONScontext* stash, FONSfont* font,
 		q->y0 = ry;
 		q->x1 = rx + x1 - x0;
 		q->y1 = ry - y1 + y0;
+		q->xadv = glyph->xadv / 10.0f;
 
 		q->s0 = x0 * stash->itw;
 		q->t0 = y0 * stash->ith;
@@ -1540,7 +1543,7 @@ float fonsTextBounds(FONScontext* stash,
 		if (glyph != NULL) {
 			fons__getQuad(stash, font, prevGlyphIndex, glyph, scale, state->spacing, &x, &y, &q);
 			if (q.x0 < minx) minx = q.x0;
-			if (q.x1 > maxx) maxx = q.x1;
+			if ((q.x0 + q.xadv) > maxx) maxx = (q.x0 + q.xadv);
 			if (stash->params.flags & FONS_ZERO_TOPLEFT) {
 				if (q.y0 < miny) miny = q.y0;
 				if (q.y1 > maxy) maxy = q.y1;

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2706,7 +2706,7 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 					rowEnd = iter.next;
 					rowWidth = iter.nextx - rowStartX; // q.x1 - rowStartX;
 					rowMinX = q.x0 - rowStartX;
-					rowMaxX = q.x1 - rowStartX;
+					rowMaxX = q.x0 + q.xadv - rowStartX;
 					wordStart = iter.str;
 					wordStartX = iter.x;
 					wordMinX = q.x0 - rowStartX;
@@ -2722,7 +2722,7 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 				if (type == NVG_CHAR || type == NVG_CJK_CHAR) {
 					rowEnd = iter.next;
 					rowWidth = iter.nextx - rowStartX;
-					rowMaxX = q.x1 - rowStartX;
+					rowMaxX = q.x0 + q.xadv - rowStartX;
 				}
 				// track last end of a word
 				if (((ptype == NVG_CHAR || ptype == NVG_CJK_CHAR) && type == NVG_SPACE) || type == NVG_CJK_CHAR) {
@@ -2756,7 +2756,7 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 						rowEnd = iter.next;
 						rowWidth = iter.nextx - rowStartX;
 						rowMinX = q.x0 - rowStartX;
-						rowMaxX = q.x1 - rowStartX;
+						rowMaxX = q.x0 + q.xadv - rowStartX;
 						wordStart = iter.str;
 						wordStartX = iter.x;
 						wordMinX = q.x0 - rowStartX;
@@ -2776,7 +2776,7 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 						rowEnd = iter.next;
 						rowWidth = iter.nextx - rowStartX;
 						rowMinX = wordMinX;
-						rowMaxX = q.x1 - rowStartX;
+						rowMaxX = q.x0 + q.xadv - rowStartX;
 						// No change to the word start
 					}
 					// Set null break point


### PR DESCRIPTION
This commit fixes the bug that `nvgTextBounds()` may return incorrect results (#206) and `nvgTextBreakLines()` may give unmatched row widths (#373).

The bug is caused by determining quad’s `x1` by calculating the difference between a glyph’s `x0` and `x1`. However, glyph’s values lose some precision after converting to the integers for locating the glyph’s position in the atlas.

That’s the reason why there might be minor difference between the actual string width (NVGtextRow’s width) and the not always correct bound width (`bounds[2] - bounds[0]` returned by `nvgTextBounds()`). The former uses glyph’s `xadv` as each glyph’s width while the latter uses glyph’s `x1 - x0` to determine the width.