### PR TITLE
Fixed Signed/Unsigned Comparison Warning

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -231,7 +231,7 @@ void fons__tt_renderGlyphBitmap(FONSttFontImpl *font, unsigned char *output, int
 {
 	FT_GlyphSlot ftGlyph = font->font->glyph;
 	int ftGlyphOffset = 0;
-	int x, y;
+	unsigned int x, y;
 	FONS_NOTUSED(outWidth);
 	FONS_NOTUSED(outHeight);
 	FONS_NOTUSED(scaleX);


### PR DESCRIPTION
In Visual Studio 17, I get warnings related to these variables:
````
fontstash.h(241): warning C4018: '<': signed/unsigned mismatch
fontstash.h(242): warning C4018: '<': signed/unsigned mismatch
````

Making them unsigned fixes it.