### PR TITLE
fix for freetype glyph loading 

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -212,7 +212,7 @@ int fons__tt_buildGlyphBitmap(FONSttFontImpl *font, int glyph, float size, float
 
 	ftError = FT_Set_Pixel_Sizes(font->font, 0, size);
 	if (ftError) return 0;
-	ftError = FT_Load_Glyph(font->font, glyph, FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT);
+	ftError = FT_Load_Glyph(font->font, glyph, FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT | FT_LOAD_TARGET_LIGHT);
 	if (ftError) return 0;
 	ftError = FT_Get_Advance(font->font, glyph, FT_LOAD_NO_SCALE, &advFixed);
 	if (ftError) return 0;


### PR DESCRIPTION
With nanovg as renderer for @rxi's excellent [lite](https://github.com/rxi/lite) code editor, I noticed the following undesirable glyph wonkiness when using FreeType:

![Screen Shot 2020-10-01 at 12 07 36 AM](https://user-images.githubusercontent.com/26006/94783118-143ae280-0381-11eb-917a-de963a2edf60.png)

The `s` glyph is particularly egregious.

Adding `FT_LOAD_TARGET_LIGHT` to the `FT_Load_Glyph` flags ([see docs](https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_load_target_xxx)) did the trick:

![Screen Shot 2020-10-01 at 12 08 16 AM](https://user-images.githubusercontent.com/26006/94783585-beb30580-0381-11eb-9a2f-e9ac744e8c12.png)



