### PR TITLE
Continous Integration for nanvog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push]
+
+env:
+  BUILD_TYPE: release
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install required packages
+      run: sudo apt-get install premake4 build-essential libglfw3-dev libglew-dev pkg-config
+
+    - name: Premake
+      run:  premake4 gmake
+
+# due to glew problems with in the current ubuntu-latest, we don't build the examples (yet)
+# https://github.com/openai/mujoco-py/issues/383 has the same problem for reference
+# this doesn't happen in focal 
+    - name: Make
+      run:  cd build && make nanovg 

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2470,7 +2470,7 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	float invscale = 1.0f / scale;
 	int cverts = 0;
 	int nverts = 0;
-	int isFlipped = nvg__isTransformFlipped(xform);
+	int isFlipped = nvg__isTransformFlipped(state->xform);
 
 	if (end == NULL)
 		end = string + strlen(string);


### PR DESCRIPTION
This PR adds a github workflow that builds nanovg (on ubuntu) for every push. Can be seen in action [here](https://github.com/mulle-nat/nanovg/actions).

This is useful, as PRs from inexperienced developers (ahem) that carry compilation errors will be caught early. This PR supersedes #603, as it also contains the compile fix. If it didn't then the CI would fail and superficially it would look, like it didn't work either. Which is something I wanted to avoid.

The CI does not build examples (yet), due to technical problems with the older ubuntu version being used by github.

