### PR TITLE
add include guard so that the gl_header can be included in multiple source files

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -105,7 +105,7 @@ enum NVGimageFlagsGL {
 
 #endif /* NANOVG_GL_H */
 
-#ifdef NANOVG_GL_IMPLEMENTATION
+#if defined NANOVG_GL_IMPLEMENTATION && !defined NANOVG_GL_HEADER_ONLY
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Hi, firstly thank you so much for the great library.

I need to include the gl header in multiple source files to use some of the gl functions such as `nvglCreateImageFromHandleGL3`, however i was getting errors because of functions being defined in multiple source files. I added an include guard for this, so it would like this in another source file that wants to use gl stuff:

```
#define NANOVG_GL_HEADER_ONLY
#define NANOVG_GL3_IMPLEMENTATION
#include "nanovg/gl/nanovg_gl.h"
```

this way only the definitions of the functions are pulled in.