### PR TITLE
Restore previous shader program on nvgEndFrame

### DIFF
--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -1180,7 +1180,7 @@ static void glnvg__renderFlush(void* uptr)
 {
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
 	int i;
-	
+
 	if (gl->ncalls > 0) {
 		GLuint lastProgram = 0;
 		glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&lastProgram);

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -1180,9 +1180,10 @@ static void glnvg__renderFlush(void* uptr)
 {
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
 	int i;
-
+	
 	if (gl->ncalls > 0) {
-
+		GLuint lastProgram = 0;
+		glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&lastProgram);
 		// Setup require GL state.
 		glUseProgram(gl->shader.prog);
 
@@ -1255,7 +1256,7 @@ static void glnvg__renderFlush(void* uptr)
 #endif
 		glDisable(GL_CULL_FACE);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
-		glUseProgram(0);
+		glUseProgram(lastProgram);
 		glnvg__bindTexture(gl, 0);
 	}
 


### PR DESCRIPTION
This change restores the previous shader program instead of setting it to 0 on nvgEndFrame()/renderFlush().

This will also help when using nanovg with other graphics libraries that manage a default shader like Cinder.