### PR TITLE
Add Get GL Texture Id

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -818,7 +818,7 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 			return -1;
 		} else {
 			const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
-			if(glTextureId<0) {
+			if(glTextureId < 0) {
 				printf("Invalid GL Texture Id for Image\n");
 			}
 		}

--- a/example/demo.c
+++ b/example/demo.c
@@ -816,7 +816,12 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 		if (data->images[i] == 0) {
 			printf("Could not load %s.\n", file);
 			return -1;
-		}
+		} else {
+		    int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
+            if(glTextureId<0) {
+                printf("Invalid GL Texture Id for Image\n");
+            }
+        }
 	}
 
 	data->fontIcons = nvgCreateFont(vg, "icons", "../example/entypo.ttf");

--- a/example/demo.c
+++ b/example/demo.c
@@ -817,7 +817,7 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 			printf("Could not load %s.\n", file);
 			return -1;
 		} else {
-		    int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
+		    const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
             if(glTextureId<0) {
                 printf("Invalid GL Texture Id for Image\n");
             }

--- a/example/demo.c
+++ b/example/demo.c
@@ -817,11 +817,11 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 			printf("Could not load %s.\n", file);
 			return -1;
 		} else {
-		    const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
-            if(glTextureId<0) {
-                printf("Invalid GL Texture Id for Image\n");
-            }
-        }
+			const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
+			if(glTextureId<0) {
+				printf("Invalid GL Texture Id for Image\n");
+			}
+		}
 	}
 
 	data->fontIcons = nvgCreateFont(vg, "icons", "../example/entypo.ttf");

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -338,6 +338,11 @@ error:
 	return 0;
 }
 
+int nvgGetImageTextureId(NVGcontext* ctx, int handle)
+{
+	return ctx->params.renderGetImageTextureId(ctx->params.userPtr, handle);
+}
+
 NVGparams* nvgInternalParams(NVGcontext* ctx)
 {
     return &ctx->params;

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -625,7 +625,7 @@ void nvgTextMetrics(NVGcontext* ctx, float* ascender, float* descender, float* l
 int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, float breakRowWidth, NVGtextRow* rows, int maxRows);
 
 // Get the GL texture id for specified image handle. Permits shaders to bind to image texture so we can
-// directly render to image while preserving z-order and not adding any frame delay.
+// directly render to image while preserving z-order.
 int nvgGetImageTextureId(NVGcontext* ctx, int handle);
 
 //

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -624,6 +624,10 @@ void nvgTextMetrics(NVGcontext* ctx, float* ascender, float* descender, float* l
 // Words longer than the max width are slit at nearest character (i.e. no hyphenation).
 int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, float breakRowWidth, NVGtextRow* rows, int maxRows);
 
+// Get the GL texture id for specified image handle. Permits shaders to bind to image texture so we can
+// directly render to image while preserving z-order and not adding any frame delay.
+int nvgGetImageTextureId(NVGcontext* ctx, int handle);
+
 //
 // Internal Render API
 //
@@ -665,6 +669,7 @@ struct NVGparams {
 	int (*renderDeleteTexture)(void* uptr, int image);
 	int (*renderUpdateTexture)(void* uptr, int image, int x, int y, int w, int h, const unsigned char* data);
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
+	int (*renderGetImageTextureId)(void* uptr, int handle);
 	void (*renderViewport)(void* uptr, float width, float height, float devicePixelRatio);
 	void (*renderCancel)(void* uptr);
 	void (*renderFlush)(void* uptr);

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -885,12 +885,12 @@ static int glnvg__renderGetTextureSize(void* uptr, int image, int* w, int* h)
 static int glnvg__renderGetImageTextureId(void* uptr, int handle)
 {
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
-    GLNVGtexture* tex = glnvg__findTexture(gl, handle);
-    if(tex) {
-        return tex->tex;
-    } else {
-        return -1;
-    }
+	GLNVGtexture* tex = glnvg__findTexture(gl, handle);
+	if(tex) {
+	    return tex->tex;
+	} else {
+	    return -1;
+	}
 }
 
 static void glnvg__xformToMat3x4(float* m3, float* t)

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -882,6 +882,17 @@ static int glnvg__renderGetTextureSize(void* uptr, int image, int* w, int* h)
 	return 1;
 }
 
+static int glnvg__renderGetImageTextureId(void* uptr, int handle)
+{
+	GLNVGcontext* gl = (GLNVGcontext*)uptr;
+    GLNVGtexture* tex = glnvg__findTexture(gl, handle);
+    if(tex) {
+        return tex->tex;
+    } else {
+        return -1;
+    }
+}
+
 static void glnvg__xformToMat3x4(float* m3, float* t)
 {
 	m3[0] = t[0];
@@ -1582,6 +1593,7 @@ NVGcontext* nvgCreateGLES3(int flags)
 	params.renderDeleteTexture = glnvg__renderDeleteTexture;
 	params.renderUpdateTexture = glnvg__renderUpdateTexture;
 	params.renderGetTextureSize = glnvg__renderGetTextureSize;
+	params.renderGetImageTextureId = glnvg__renderGetImageTextureId;
 	params.renderViewport = glnvg__renderViewport;
 	params.renderCancel = glnvg__renderCancel;
 	params.renderFlush = glnvg__renderFlush;


### PR DESCRIPTION
This PR adds the ability to retrieve the GL texture Id for an image allocated by NVG. The idea is that we would want to map a frame buffer to an existing NVG image to render a shader with some type of animation. It's better to use an existing NVG texture because it preserves z-order with other NVG components. 