### PR TITLE
Font Dilation (font outline)

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -360,6 +360,20 @@ void drawSlider(NVGcontext* vg, float pos, float x, float y, float w, float h)
 	nvgRestore(vg);
 }
 
+void drawFancyText(NVGcontext* vg, float x, float y, const char* text){
+	nvgFontSize(vg, 50.0f);
+	nvgFontFace(vg, "sans-bold");
+	nvgTextAlign(vg,NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
+	nvgFontDilate(vg, 3); // dilate will always be applied before blur
+	nvgFontBlur(vg, 1);
+	nvgFillColor(vg, nvgRGB(255, 51, 204));
+	nvgText(vg, x, y, text, NULL);
+	nvgFontDilate(vg,0);
+	nvgFontBlur(vg,0);
+	nvgFillColor(vg, nvgRGB(255,255,255));
+	nvgText(vg, x, y, text, NULL);
+}
+
 void drawEyes(NVGcontext* vg, float x, float y, float w, float h, float mx, float my, float t)
 {
 	NVGpaint gloss, bg;
@@ -1073,6 +1087,7 @@ void renderDemo(NVGcontext* vg, float mx, float my, float width, float height,
 	float x,y,popy;
 
 	drawEyes(vg, width - 250, 50, 150, 100, mx, my, t);
+	drawFancyText(vg, width - 150, 220, "Font Outline");
 	drawParagraph(vg, width - 450, 50, 150, 100, mx, my);
 	drawGraph(vg, 0, height/2, width, height/2, t);
 	drawColorwheel(vg, width - 300, height - 300, 250.0f, 250.0f, t);

--- a/example/demo.c
+++ b/example/demo.c
@@ -818,7 +818,7 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 			return -1;
 		} else {
 			const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
-			if(glTextureId<0) {
+			if(glTextureId < 0) {
 				printf("Invalid GL Texture Id for Image\n");
 			}
 		}

--- a/example/demo.c
+++ b/example/demo.c
@@ -816,7 +816,12 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 		if (data->images[i] == 0) {
 			printf("Could not load %s.\n", file);
 			return -1;
-		}
+		} else {
+		    int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
+            if(glTextureId<0) {
+                printf("Invalid GL Texture Id for Image\n");
+            }
+        }
 	}
 
 	data->fontIcons = nvgCreateFont(vg, "icons", "../example/entypo.ttf");

--- a/example/demo.c
+++ b/example/demo.c
@@ -364,7 +364,7 @@ void drawFancyText(NVGcontext* vg, float x, float y, const char* text){
 	nvgFontSize(vg, 50.0f);
 	nvgFontFace(vg, "sans-bold");
 	nvgTextAlign(vg,NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
-	nvgFontDilate(vg, 3); // dilate will always be applied before blur
+	nvgFontDilate(vg, 2); // Dilate will always be applied before blur
 	nvgFontBlur(vg, 1);
 	nvgFillColor(vg, nvgRGB(255, 51, 204));
 	nvgText(vg, x, y, text, NULL);

--- a/example/demo.c
+++ b/example/demo.c
@@ -360,18 +360,33 @@ void drawSlider(NVGcontext* vg, float pos, float x, float y, float w, float h)
 	nvgRestore(vg);
 }
 
-void drawFancyText(NVGcontext* vg, float x, float y, const char* text){
-	nvgFontSize(vg, 50.0f);
+void drawFancyText(NVGcontext* vg, float x, float y){
+	nvgFontSize(vg, 30.0f);
 	nvgFontFace(vg, "sans-bold");
 	nvgTextAlign(vg,NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
-	nvgFontDilate(vg, 2); // Dilate will always be applied before blur
-	nvgFontBlur(vg, 1);
-	nvgFillColor(vg, nvgRGB(255, 51, 204));
-	nvgText(vg, x, y, text, NULL);
+
+	nvgFontBlur(vg, 10);
+	nvgFillColor(vg, nvgRGB(255, 0, 102));
+	nvgText(vg, x, y, "Font Blur", NULL);
+	nvgFontBlur(vg,0);
+	nvgFillColor(vg, nvgRGB(255,255,255));
+	nvgText(vg, x, y, "Font Blur", NULL);
+
+	nvgFontDilate(vg, 2);
+	nvgFillColor(vg, nvgRGB(255, 0, 102));
+	nvgText(vg, x, y+40, "Font Outline", NULL);
+	nvgFontDilate(vg,0);
+	nvgFillColor(vg, nvgRGB(255,255,255));
+	nvgText(vg, x, y+40, "Font Outline", NULL);
+
+	nvgFontDilate(vg, 3); // Dilate will always be applied before blur
+	nvgFontBlur(vg, 2);
+	nvgFillColor(vg, nvgRGB(255, 0, 102));
+	nvgText(vg, x, y+80, "Font Blur Outline", NULL);
 	nvgFontDilate(vg,0);
 	nvgFontBlur(vg,0);
 	nvgFillColor(vg, nvgRGB(255,255,255));
-	nvgText(vg, x, y, text, NULL);
+	nvgText(vg, x, y+80, "Font Blur Outline", NULL);
 }
 
 void drawEyes(NVGcontext* vg, float x, float y, float w, float h, float mx, float my, float t)
@@ -1082,7 +1097,7 @@ void renderDemo(NVGcontext* vg, float mx, float my, float width, float height,
 	float x,y,popy;
 
 	drawEyes(vg, width - 250, 50, 150, 100, mx, my, t);
-	drawFancyText(vg, width - 150, 220, "Font Outline");
+	drawFancyText(vg, width - 175, 190);
 	drawParagraph(vg, width - 450, 50, 150, 100, mx, my);
 	drawGraph(vg, 0, height/2, width, height/2, t);
 	drawColorwheel(vg, width - 300, height - 300, 250.0f, 250.0f, t);

--- a/example/demo.c
+++ b/example/demo.c
@@ -817,7 +817,7 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 			printf("Could not load %s.\n", file);
 			return -1;
 		} else {
-		    int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
+		    const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
             if(glTextureId<0) {
                 printf("Invalid GL Texture Id for Image\n");
             }

--- a/example/demo.c
+++ b/example/demo.c
@@ -830,11 +830,6 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 		if (data->images[i] == 0) {
 			printf("Could not load %s.\n", file);
 			return -1;
-		} else {
-			const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
-			if(glTextureId < 0) {
-				printf("Invalid GL Texture Id for Image\n");
-			}
 		}
 	}
 

--- a/example/demo.c
+++ b/example/demo.c
@@ -817,11 +817,11 @@ int loadDemoData(NVGcontext* vg, DemoData* data)
 			printf("Could not load %s.\n", file);
 			return -1;
 		} else {
-		    const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
-            if(glTextureId<0) {
-                printf("Invalid GL Texture Id for Image\n");
-            }
-        }
+			const int glTextureId = nvgGetImageTextureId(vg, data->images[i]);
+			if(glTextureId<0) {
+				printf("Invalid GL Texture Id for Image\n");
+			}
+		}
 	}
 
 	data->fontIcons = nvgCreateFont(vg, "icons", "../example/entypo.ttf");

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1081,17 +1081,18 @@ static void fons__blur(FONScontext* stash, unsigned char* dst, int w, int h, int
 static void fons__maxRows(unsigned char* dst, int w, int h, int dstStride)
 {
 	int x, y;
+	unsigned char prev, current;
 	for (x = 0; x < w; x++) {
-		unsigned char prev=dst[0];
+		prev=dst[0];
 		for (y = dstStride; y < h*dstStride; y += dstStride) {
-			unsigned char current=dst[y];
+			current=dst[y];
 			if(prev > current){
 				dst[y]=prev;
 			}
 			prev=current;
 		}
 		for (y = (h-2)*dstStride; y >= 0; y -= dstStride) {
-			unsigned char current=dst[y];
+			current=dst[y];
 			if(prev > current){
 				dst[y]=prev;
 			}
@@ -1128,13 +1129,13 @@ static void fons__maxCols(unsigned char* dst, int w, int h, int dstStride)
 static void fons__maxDiagUp(unsigned char* dst, int w, int h, int dstStride)
 {
 	int t, y;
-	const int d=w+h;
 	const int a =dstStride-1;
+	const int d=w+h;
 	unsigned char prev, current;
 	for(t=0;t<d;t++){
 		const int y_min=(t-w<0)?0:t-w;
 		const int y_max=(t<h-1)?t:h-1;
-		prev=(unsigned char)(dst[t+y_min*a]);
+		prev=dst[t+y_min*a];
 		for(y=y_min;y<=y_max;y++){
 			current=dst[t+y*a];
 			if(prev > current){
@@ -1155,14 +1156,14 @@ static void fons__maxDiagUp(unsigned char* dst, int w, int h, int dstStride)
 static void fons__maxDiagDown(unsigned char* dst, int w, int h, int dstStride)
 {
 	int t, y;
-	const int d=w+h;
 	const int a=(h-1)*dstStride;
 	const int b=dstStride+1;
+	const int d=w+h;
 	unsigned char prev, current;
 	for(t=0;t<d;t++){
 		const int y_min=(t-w<0)?0:t-w;
 		const int y_max=(t<h-1)?t:h-1;
-		prev=(unsigned char)(dst[t-y_min*b+a]);
+		prev=dst[t-y_min*b+a];
 		for(y=y_min;y<=y_max;y++){
 			current=dst[t-y*b+a];
 			if(prev > current){

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1182,7 +1182,7 @@ static void fons__maxDiagDown(unsigned char* dst, int w, int h, int dstStride)
 }
 
 // Gray level morphological dilation approximated by convoling with a max stencil along
-// Diagonal convolution overlaps with  horizontal and vertical, so we alternate between vertical & horizontal
+// Diagonal convolution overlaps with horizontal & vertical, so we alternate between vertical & horizontal
 // and diagonal directions to prevent the dilation from being too large.
 static void fons__dilate(FONScontext* stash, unsigned char* dst, int w, int h, int dstStride, int dilate)
 {

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1193,7 +1193,7 @@ static void fons__maxDiagDown(unsigned char* dst, int w, int h, int dstStride)
 	}
 }
 
-// Gray level morphological dilation approximated by convoling with a max stencil along
+// Gray level morphological dilation approximated by convolving with a max stencil along
 // Diagonal convolution overlaps with horizontal & vertical, so we alternate between vertical & horizontal
 // and diagonal directions to prevent the dilation from being too large.
 static void fons__dilate(FONScontext* stash, unsigned char* dst, int w, int h, int dstStride, int dilate)

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1151,7 +1151,7 @@ static void fons__maxDiagUp(unsigned char* dst, int w, int h, int dstStride)
 			}
 			prev=current;
 		}
-		for(y=y_max-2;y>=y_min;y--){
+		for(y=y_max-1;y>=y_min;y--){
 			ptr=&dst[t+y*a];
 			current=*ptr;
 			if(prev > current){
@@ -1182,7 +1182,7 @@ static void fons__maxDiagDown(unsigned char* dst, int w, int h, int dstStride)
 			}
 			prev=current;
 		}
-		for(y=y_max-2;y>=y_min;y--){
+		for(y=y_max-1;y>=y_min;y--){
 			ptr=&dst[t-y*b+a];
 			current=*ptr;
 			if(prev > current){

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1228,7 +1228,7 @@ static FONSglyph* fons__getGlyph(FONScontext* stash, FONSfont* font, unsigned in
 	if (iblur > 20) iblur = 20;
 	if (idilate > 20) idilate = 20;
 	const int antiAliasBonus = 2;
-	pad= antiAliasBonus + iblur + idilate;
+	pad = antiAliasBonus + iblur + idilate;
 
 	// Reset allocator.
 	stash->nscratch = 0;

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1082,19 +1082,22 @@ static void fons__maxRows(unsigned char* dst, int w, int h, int dstStride)
 {
 	int x, y;
 	unsigned char prev, current;
+	unsigned char* ptr;
 	for (x = 0; x < w; x++) {
 		prev=dst[0];
 		for (y = dstStride; y < h*dstStride; y += dstStride) {
-			current=dst[y];
+			ptr=&dst[y];
+			current=*ptr;
 			if(prev > current){
-				dst[y]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}
 		for (y = (h-2)*dstStride; y >= 0; y -= dstStride) {
-			current=dst[y];
+			ptr=&dst[y];
+			current=*ptr;
 			if(prev > current){
-				dst[y]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}
@@ -1106,19 +1109,22 @@ static void fons__maxCols(unsigned char* dst, int w, int h, int dstStride)
 {
 	int x, y;
 	unsigned char prev, current;
+	unsigned char* ptr;
 	for (y = 0; y < h; y++) {
 		prev=dst[0];
 		for (x = 1; x < w; x++) {
-			current=dst[x];
+			ptr=&dst[x];
+			current=*ptr;
 			if(prev > current){
-				dst[x]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}
 		for (x = w-2; x >= 0; x--) {
-			current=dst[x];
+			ptr=&dst[x];
+			current=*ptr;
 			if(prev > current){
-				dst[x]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}
@@ -1132,21 +1138,24 @@ static void fons__maxDiagUp(unsigned char* dst, int w, int h, int dstStride)
 	const int a =dstStride-1;
 	const int d=w+h;
 	unsigned char prev, current;
+	unsigned char* ptr;
 	for(t=0;t<d;t++){
 		const int y_min=(t-w<0)?0:t-w;
 		const int y_max=(t<h-1)?t:h-1;
 		prev=dst[t+y_min*a];
 		for(y=y_min;y<=y_max;y++){
-			current=dst[t+y*a];
+			ptr=&dst[t+y*a];
+			current=*ptr;
 			if(prev > current){
-				dst[t+y*a]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}
 		for(y=y_max-2;y>=y_min;y--){
-			current=dst[t+y*a];
+			ptr=&dst[t+y*a];
+			current=*ptr;
 			if(prev > current){
-				dst[t+y*a]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}
@@ -1160,21 +1169,24 @@ static void fons__maxDiagDown(unsigned char* dst, int w, int h, int dstStride)
 	const int b=dstStride+1;
 	const int d=w+h;
 	unsigned char prev, current;
+	unsigned char* ptr;
 	for(t=0;t<d;t++){
 		const int y_min=(t-w<0)?0:t-w;
 		const int y_max=(t<h-1)?t:h-1;
 		prev=dst[t-y_min*b+a];
 		for(y=y_min;y<=y_max;y++){
-			current=dst[t-y*b+a];
+			ptr=&dst[t-y*b+a];
+			current=*ptr;
 			if(prev > current){
-				dst[t-y*b+a]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}
 		for(y=y_max-2;y>=y_min;y--){
-			current=dst[t-y*b+a];
+			ptr=&dst[t-y*b+a];
+			current=*ptr;
 			if(prev > current){
-				dst[t-y*b+a]=prev;
+				*ptr=prev;
 			}
 			prev=current;
 		}

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1180,6 +1180,9 @@ static void fons__maxDiagDown(unsigned char* dst, int w, int h, int dstStride)
 	}
 }
 
+// Gray level morphological dilation approximated by convoling with a max stencil along
+// Diagonal convolution overlaps with  horizontal and vertical, so we alternate between vertical & horizontal
+// and diagonal directions to prevent the dilation from being too large.
 static void fons__dilate(FONScontext* stash, unsigned char* dst, int w, int h, int dstStride, int dilate)
 {
 	(void)stash;

--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1134,7 +1134,7 @@ static void fons__maxDiagUp(unsigned char* dst, int w, int h, int dstStride)
 	for(t=0;t<d;t++){
 		const int y_min=(t-w<0)?0:t-w;
 		const int y_max=(t<h-1)?t:h-1;
-		prev=(unsigned char)(dst[(t-y_min)+y_min*dstStride]);
+		prev=(unsigned char)(dst[t+y_min*a]);
 		for(y=y_min;y<=y_max;y++){
 			current=dst[t+y*a];
 			if(prev > current){

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -339,11 +339,6 @@ error:
 	return 0;
 }
 
-int nvgGetImageTextureId(NVGcontext* ctx, int handle)
-{
-	return ctx->params.renderGetImageTextureId(ctx->params.userPtr, handle);
-}
-
 NVGparams* nvgInternalParams(NVGcontext* ctx)
 {
     return &ctx->params;

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -84,6 +84,7 @@ struct NVGstate {
 	float letterSpacing;
 	float lineHeight;
 	float fontBlur;
+	float fontDilate;
 	int textAlign;
 	int fontId;
 };
@@ -669,6 +670,7 @@ void nvgReset(NVGcontext* ctx)
 	state->letterSpacing = 0.0f;
 	state->lineHeight = 1.0f;
 	state->fontBlur = 0.0f;
+	state->fontDilate = 0.0f;
 	state->textAlign = NVG_ALIGN_LEFT | NVG_ALIGN_BASELINE;
 	state->fontId = 0;
 }
@@ -2358,6 +2360,12 @@ void nvgFontBlur(NVGcontext* ctx, float blur)
 	state->fontBlur = blur;
 }
 
+void nvgFontDilate(NVGcontext* ctx, float dilate)
+{
+	NVGstate* state = nvg__getState(ctx);
+	state->fontDilate = dilate;
+}
+
 void nvgTextLetterSpacing(NVGcontext* ctx, float spacing)
 {
 	NVGstate* state = nvg__getState(ctx);
@@ -2485,6 +2493,7 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	fonsSetSize(ctx->fs, state->fontSize*scale);
 	fonsSetSpacing(ctx->fs, state->letterSpacing*scale);
 	fonsSetBlur(ctx->fs, state->fontBlur*scale);
+	fonsSetDilate(ctx->fs, state->fontDilate*scale);
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 
@@ -2656,6 +2665,7 @@ int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, floa
 	fonsSetSize(ctx->fs, state->fontSize*scale);
 	fonsSetSpacing(ctx->fs, state->letterSpacing*scale);
 	fonsSetBlur(ctx->fs, state->fontBlur*scale);
+	fonsSetDilate(ctx->fs, state->fontDilate*scale);
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 
@@ -2840,6 +2850,7 @@ float nvgTextBounds(NVGcontext* ctx, float x, float y, const char* string, const
 	fonsSetSize(ctx->fs, state->fontSize*scale);
 	fonsSetSpacing(ctx->fs, state->letterSpacing*scale);
 	fonsSetBlur(ctx->fs, state->fontBlur*scale);
+	fonsSetDilate(ctx->fs, state->fontDilate*scale);
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 
@@ -2884,6 +2895,7 @@ void nvgTextBoxBounds(NVGcontext* ctx, float x, float y, float breakRowWidth, co
 	fonsSetSize(ctx->fs, state->fontSize*scale);
 	fonsSetSpacing(ctx->fs, state->letterSpacing*scale);
 	fonsSetBlur(ctx->fs, state->fontBlur*scale);
+	fonsSetDilate(ctx->fs, state->fontDilate*scale);
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 	fonsLineBounds(ctx->fs, 0, &rminy, &rmaxy);
@@ -2935,6 +2947,7 @@ void nvgTextMetrics(NVGcontext* ctx, float* ascender, float* descender, float* l
 	fonsSetSize(ctx->fs, state->fontSize*scale);
 	fonsSetSpacing(ctx->fs, state->letterSpacing*scale);
 	fonsSetBlur(ctx->fs, state->fontBlur*scale);
+	fonsSetDilate(ctx->fs, state->fontDilate*scale);
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -338,6 +338,11 @@ error:
 	return 0;
 }
 
+int nvgGetImageTextureId(NVGcontext* ctx, int handle)
+{
+	return ctx->params.renderGetImageTextureId(ctx->params.userPtr, handle);
+}
+
 NVGparams* nvgInternalParams(NVGcontext* ctx)
 {
     return &ctx->params;

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -625,7 +625,7 @@ void nvgTextMetrics(NVGcontext* ctx, float* ascender, float* descender, float* l
 int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, float breakRowWidth, NVGtextRow* rows, int maxRows);
 
 // Get the GL texture id for specified image handle. Permits shaders to bind to image texture so we can
-// directly render to image while preserving z-order and not adding any frame delay.
+// directly render to image while preserving z-order.
 int nvgGetImageTextureId(NVGcontext* ctx, int handle);
 
 //

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -624,6 +624,10 @@ void nvgTextMetrics(NVGcontext* ctx, float* ascender, float* descender, float* l
 // Words longer than the max width are slit at nearest character (i.e. no hyphenation).
 int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, float breakRowWidth, NVGtextRow* rows, int maxRows);
 
+// Get the GL texture id for specified image handle. Permits shaders to bind to image texture so we can
+// directly render to image while preserving z-order and not adding any frame delay.
+int nvgGetImageTextureId(NVGcontext* ctx, int handle);
+
 //
 // Internal Render API
 //
@@ -665,6 +669,7 @@ struct NVGparams {
 	int (*renderDeleteTexture)(void* uptr, int image);
 	int (*renderUpdateTexture)(void* uptr, int image, int x, int y, int w, int h, const unsigned char* data);
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
+	int (*renderGetImageTextureId)(void* uptr, int handle);
 	void (*renderViewport)(void* uptr, float width, float height, float devicePixelRatio);
 	void (*renderCancel)(void* uptr);
 	void (*renderFlush)(void* uptr);

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -577,6 +577,9 @@ void nvgFontSize(NVGcontext* ctx, float size);
 // Sets the blur of current text style.
 void nvgFontBlur(NVGcontext* ctx, float blur);
 
+// Sets the dilation of current text style.
+void nvgFontDilate(NVGcontext* ctx, float dilate);
+
 // Sets the letter spacing of current text style.
 void nvgTextLetterSpacing(NVGcontext* ctx, float spacing);
 

--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -627,10 +627,6 @@ void nvgTextMetrics(NVGcontext* ctx, float* ascender, float* descender, float* l
 // Words longer than the max width are slit at nearest character (i.e. no hyphenation).
 int nvgTextBreakLines(NVGcontext* ctx, const char* string, const char* end, float breakRowWidth, NVGtextRow* rows, int maxRows);
 
-// Get the GL texture id for specified image handle. Permits shaders to bind to image texture so we can
-// directly render to image while preserving z-order.
-int nvgGetImageTextureId(NVGcontext* ctx, int handle);
-
 //
 // Internal Render API
 //
@@ -672,7 +668,6 @@ struct NVGparams {
 	int (*renderDeleteTexture)(void* uptr, int image);
 	int (*renderUpdateTexture)(void* uptr, int image, int x, int y, int w, int h, const unsigned char* data);
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
-	int (*renderGetImageTextureId)(void* uptr, int handle);
 	void (*renderViewport)(void* uptr, float width, float height, float devicePixelRatio);
 	void (*renderCancel)(void* uptr);
 	void (*renderFlush)(void* uptr);

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -885,12 +885,12 @@ static int glnvg__renderGetTextureSize(void* uptr, int image, int* w, int* h)
 static int glnvg__renderGetImageTextureId(void* uptr, int handle)
 {
 	GLNVGcontext* gl = (GLNVGcontext*)uptr;
-    GLNVGtexture* tex = glnvg__findTexture(gl, handle);
-    if(tex) {
-        return tex->tex;
-    } else {
-        return -1;
-    }
+	GLNVGtexture* tex = glnvg__findTexture(gl, handle);
+	if(tex) {
+	    return tex->tex;
+	} else {
+	    return -1;
+	}
 }
 
 static void glnvg__xformToMat3x4(float* m3, float* t)

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -882,6 +882,17 @@ static int glnvg__renderGetTextureSize(void* uptr, int image, int* w, int* h)
 	return 1;
 }
 
+static int glnvg__renderGetImageTextureId(void* uptr, int handle)
+{
+	GLNVGcontext* gl = (GLNVGcontext*)uptr;
+    GLNVGtexture* tex = glnvg__findTexture(gl, handle);
+    if(tex) {
+        return tex->tex;
+    } else {
+        return -1;
+    }
+}
+
 static void glnvg__xformToMat3x4(float* m3, float* t)
 {
 	m3[0] = t[0];
@@ -1582,6 +1593,7 @@ NVGcontext* nvgCreateGLES3(int flags)
 	params.renderDeleteTexture = glnvg__renderDeleteTexture;
 	params.renderUpdateTexture = glnvg__renderUpdateTexture;
 	params.renderGetTextureSize = glnvg__renderGetTextureSize;
+	params.renderGetImageTextureId = glnvg__renderGetImageTextureId;
 	params.renderViewport = glnvg__renderViewport;
 	params.renderCancel = glnvg__renderCancel;
 	params.renderFlush = glnvg__renderFlush;

--- a/src/nanovg_gl.h
+++ b/src/nanovg_gl.h
@@ -882,17 +882,6 @@ static int glnvg__renderGetTextureSize(void* uptr, int image, int* w, int* h)
 	return 1;
 }
 
-static int glnvg__renderGetImageTextureId(void* uptr, int handle)
-{
-	GLNVGcontext* gl = (GLNVGcontext*)uptr;
-	GLNVGtexture* tex = glnvg__findTexture(gl, handle);
-	if(tex) {
-	    return tex->tex;
-	} else {
-	    return -1;
-	}
-}
-
 static void glnvg__xformToMat3x4(float* m3, float* t)
 {
 	m3[0] = t[0];
@@ -1593,7 +1582,6 @@ NVGcontext* nvgCreateGLES3(int flags)
 	params.renderDeleteTexture = glnvg__renderDeleteTexture;
 	params.renderUpdateTexture = glnvg__renderUpdateTexture;
 	params.renderGetTextureSize = glnvg__renderGetTextureSize;
-	params.renderGetImageTextureId = glnvg__renderGetImageTextureId;
 	params.renderViewport = glnvg__renderViewport;
 	params.renderCancel = glnvg__renderCancel;
 	params.renderFlush = glnvg__renderFlush;


### PR DESCRIPTION
This PR adds font dilation as nvgFontDilate() to give better emphasis to text, especially when it is overlaid on an unknown background color or image. It is implemented with gray level morphology, which is approximated with directional convolutions. It can also be used in combination with nvgFontBlur() for a smoother fall-off.
![dump](https://user-images.githubusercontent.com/2365573/180819198-00760a4b-a115-42c6-8ad7-9125f2abe844.png)

