### PR TITLE
Fix text jitter for animated (moving) text

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -24,6 +24,7 @@
 #define ICON_LOGIN 0xE740
 #define ICON_TRASH 0xE729
 
+static int mini(int a, int b) { return a < b ? a : b; }
 //static float minf(float a, float b) { return a < b ? a : b; }
 //static float maxf(float a, float b) { return a > b ? a : b; }
 //static float absf(float a) { return a >= 0.0f ? a : -a; }
@@ -745,6 +746,28 @@ void drawColorwheel(NVGcontext* vg, float x, float y, float w, float h, float t)
 
 	nvgRestore(vg);
 
+	float tw = 50;
+	float th = 25;
+	r1 += 0.5f*sqrt(tw*tw+th*th);
+	nvgBeginPath(vg);
+	nvgFillColor(vg, nvgRGB(32,32,32));
+	ax=cosf(hue*NVG_PI*2);
+	ay=sinf(hue*NVG_PI*2);
+	ax=cx+r1*ax;
+	ay=cy+r1*ay;
+	nvgRoundedRect(vg, ax - tw*0.5f, ay -th*0.5f, tw, th,5.0f);
+	nvgFill(vg);
+
+	nvgTextAlign(vg, NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
+	nvgFontSize(vg, th);
+	nvgFontFace(vg, "sans");
+	nvgFillColor(vg, nvgRGB(255,255,255));
+	char str[128];
+	sprintf(str, "%d%%", mini(99, abs((int)floor(hue*100))));
+	nvgBeginPath(vg);
+	nvgText(vg, ax, ay+2.0f, str, 0);
+	nvgFill(vg);
+
 	nvgRestore(vg);
 }
 
@@ -1124,8 +1147,6 @@ void renderDemo(NVGcontext* vg, float mx, float my, float width, float height,
 
 	nvgRestore(vg);
 }
-
-static int mini(int a, int b) { return a < b ? a : b; }
 
 static void unpremultiplyAlpha(unsigned char* image, int w, int h, int stride)
 {

--- a/example/demo.c
+++ b/example/demo.c
@@ -763,7 +763,7 @@ void drawColorwheel(NVGcontext* vg, float x, float y, float w, float h, float t)
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGB(255,255,255));
 	char str[128];
-	sprintf(str, "%d%%", mini(99, abs((int)floor(hue*100))));
+	sprintf(str, "%d%%", (int)(100.0f * (hue+1)) % 100);
 	nvgBeginPath(vg);
 	nvgText(vg, ax, ay+2.0f, str, 0);
 	nvgFill(vg);

--- a/example/demo.c
+++ b/example/demo.c
@@ -24,7 +24,6 @@
 #define ICON_LOGIN 0xE740
 #define ICON_TRASH 0xE729
 
-static int mini(int a, int b) { return a < b ? a : b; }
 //static float minf(float a, float b) { return a < b ? a : b; }
 //static float maxf(float a, float b) { return a > b ? a : b; }
 //static float absf(float a) { return a >= 0.0f ? a : -a; }
@@ -1147,6 +1146,8 @@ void renderDemo(NVGcontext* vg, float mx, float my, float width, float height,
 
 	nvgRestore(vg);
 }
+
+static int mini(int a, int b) { return a < b ? a : b; }
 
 static void unpremultiplyAlpha(unsigned char* image, int w, int h, int stride)
 {

--- a/example/demo.c
+++ b/example/demo.c
@@ -756,16 +756,25 @@ void drawColorwheel(NVGcontext* vg, float x, float y, float w, float h, float t)
 	nvgRoundedRect(vg, ax - tw*0.5f, ay -th*0.5f, tw, th,5.0f);
 	nvgFill(vg);
 
-	nvgTextAlign(vg, NVG_ALIGN_CENTER|NVG_ALIGN_MIDDLE);
-	nvgFontSize(vg, th);
+	nvgSave(vg);
+	nvgTranslate(vg, ax, ay);
+	nvgScale(vg, 2.0f, 2.0f); // Check that local transforms work with text
+	nvgFontSize(vg, 0.5f * th);
+	nvgTextAlign(vg, NVG_ALIGN_CENTER|NVG_ALIGN_TOP);
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGB(255,255,255));
 	char str[128];
 	sprintf(str, "%d%%", (int)(100.0f * (hue + 1.0f)) % 100);
 	nvgBeginPath(vg);
-	nvgText(vg, ax, ay+2.0f, str, 0);
+	nvgText(vg, 0.0f, -0.25f * th, str, 0);
 	nvgFill(vg);
-
+	float bounds[4];
+	nvgTextBounds(vg, 0.0f, -0.25f * th, str, 0, bounds);
+	nvgBeginPath(vg);
+	nvgRect(vg, bounds[0], bounds[1], bounds[2] - bounds[0], bounds[3] - bounds[1]);
+	nvgStrokeColor(vg, nvgRGBA(0,255,255,128));
+	nvgStroke(vg);
+	nvgRestore(vg);
 	nvgRestore(vg);
 }
 

--- a/example/demo.c
+++ b/example/demo.c
@@ -745,15 +745,14 @@ void drawColorwheel(NVGcontext* vg, float x, float y, float w, float h, float t)
 
 	nvgRestore(vg);
 
-	float tw = 50;
-	float th = 25;
+	// Render hue label
+	const float tw = 50;
+	const float th = 25;
 	r1 += 0.5f*sqrt(tw*tw+th*th);
 	nvgBeginPath(vg);
 	nvgFillColor(vg, nvgRGB(32,32,32));
-	ax=cosf(hue*NVG_PI*2);
-	ay=sinf(hue*NVG_PI*2);
-	ax=cx+r1*ax;
-	ay=cy+r1*ay;
+	ax = cx + r1*cosf(hue*NVG_PI*2);
+	ay = cy + r1*sinf(hue*NVG_PI*2);
 	nvgRoundedRect(vg, ax - tw*0.5f, ay -th*0.5f, tw, th,5.0f);
 	nvgFill(vg);
 
@@ -762,7 +761,7 @@ void drawColorwheel(NVGcontext* vg, float x, float y, float w, float h, float t)
 	nvgFontFace(vg, "sans");
 	nvgFillColor(vg, nvgRGB(255,255,255));
 	char str[128];
-	sprintf(str, "%d%%", (int)(100.0f * (hue+1)) % 100);
+	sprintf(str, "%d%%", (int)(100.0f * (hue + 1.0f)) % 100);
 	nvgBeginPath(vg);
 	nvgText(vg, ax, ay+2.0f, str, 0);
 	nvgFill(vg);

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -132,6 +132,7 @@ struct NVGcontext {
 	int fillTriCount;
 	int strokeTriCount;
 	int textTriCount;
+	int textTextureDirty;
 };
 
 static float nvg__sqrtf(float a) { return sqrtf(a); }
@@ -163,6 +164,7 @@ static float nvg__normalize(float *x, float* y)
 	return d;
 }
 
+static void nvg__flushTextTexture(NVGcontext* ctx);
 
 static void nvg__deletePathCache(NVGpathCache* c)
 {
@@ -384,6 +386,7 @@ void nvgBeginFrame(NVGcontext* ctx, float windowWidth, float windowHeight, float
 	ctx->fillTriCount = 0;
 	ctx->strokeTriCount = 0;
 	ctx->textTriCount = 0;
+	ctx->textTextureDirty = 0;
 }
 
 void nvgCancelFrame(NVGcontext* ctx)
@@ -393,6 +396,10 @@ void nvgCancelFrame(NVGcontext* ctx)
 
 void nvgEndFrame(NVGcontext* ctx)
 {
+    if(ctx->textTextureDirty != 0) {
+        nvg__flushTextTexture(ctx);
+        ctx->textTextureDirty=0;
+    }
 	ctx->params.renderFlush(ctx->params.userPtr);
 	if (ctx->fontImageIdx != 0) {
 		int fontImage = ctx->fontImages[ctx->fontImageIdx];
@@ -2467,7 +2474,6 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	FONSquad q;
 	NVGvertex* verts;
 	float scale = nvg__getFontScale(state) * ctx->devicePxRatio;
-	float invscale = 1.0f / scale;
 	int cverts = 0;
 	int nverts = 0;
 	int isFlipped = nvg__isTransformFlipped(state->xform);
@@ -2487,7 +2493,7 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	verts = nvg__allocTempVerts(ctx, cverts);
 	if (verts == NULL) return x;
 
-	fonsTextIterInit(ctx->fs, &iter, x*scale, y*scale, string, end, FONS_GLYPH_BITMAP_REQUIRED);
+	fonsTextIterInit(ctx->fs, &iter, 0.0f, 0.0f, string, end, FONS_GLYPH_BITMAP_REQUIRED);
 	prevIter = iter;
 	while (fonsTextIterNext(ctx->fs, &iter, &q)) {
 		float c[4*2];
@@ -2511,10 +2517,11 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 			tmp = q.t0; q.t0 = q.t1; q.t1 = tmp;
 		}
 		// Transform corners.
-		nvgTransformPoint(&c[0],&c[1], state->xform, q.x0*invscale, q.y0*invscale);
-		nvgTransformPoint(&c[2],&c[3], state->xform, q.x1*invscale, q.y0*invscale);
-		nvgTransformPoint(&c[4],&c[5], state->xform, q.x1*invscale, q.y1*invscale);
-		nvgTransformPoint(&c[6],&c[7], state->xform, q.x0*invscale, q.y1*invscale);
+		nvgTransformPoint(&c[0],&c[1], state->xform, q.x0+x, q.y0+y);
+        nvgTransformPoint(&c[2],&c[3], state->xform, q.x1+x, q.y0+y);
+        nvgTransformPoint(&c[4],&c[5], state->xform, q.x1+x, q.y1+y);
+        nvgTransformPoint(&c[6],&c[7], state->xform, q.x0+x, q.y1+y);
+
 		// Create triangles
 		if (nverts+6 <= cverts) {
 			nvg__vset(&verts[nverts], c[0], c[1], q.s0, q.t0); nverts++;
@@ -2527,11 +2534,9 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	}
 
 	// TODO: add back-end bit to do this just once per frame.
-	nvg__flushTextTexture(ctx);
-
+	ctx->textTextureDirty = 1;
 	nvg__renderText(ctx, verts, nverts);
-
-	return iter.nextx / scale;
+	return iter.nextx + x;
 }
 
 void nvgTextBox(NVGcontext* ctx, float x, float y, float breakRowWidth, const char* string, const char* end)
@@ -2838,14 +2843,14 @@ float nvgTextBounds(NVGcontext* ctx, float x, float y, const char* string, const
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 
-	width = fonsTextBounds(ctx->fs, x*scale, y*scale, string, end, bounds);
+	width = fonsTextBounds(ctx->fs, 0.0f, 0.0f, string, end, bounds);
 	if (bounds != NULL) {
 		// Use line bounds for height.
-		fonsLineBounds(ctx->fs, y*scale, &bounds[1], &bounds[3]);
-		bounds[0] *= invscale;
-		bounds[1] *= invscale;
-		bounds[2] *= invscale;
-		bounds[3] *= invscale;
+		fonsLineBounds(ctx->fs, 0.0f, &bounds[1], &bounds[3]);
+        bounds[0] += x;
+        bounds[1] += y;
+        bounds[2] += x;
+        bounds[3] += y;
 	}
 	return width * invscale;
 }
@@ -2856,6 +2861,7 @@ void nvgTextBoxBounds(NVGcontext* ctx, float x, float y, float breakRowWidth, co
 	NVGtextRow rows[2];
 	float scale = nvg__getFontScale(state) * ctx->devicePxRatio;
 	float invscale = 1.0f / scale;
+	float yoff = 0;
 	int nrows = 0, i;
 	int oldAlign = state->textAlign;
 	int haling = state->textAlign & (NVG_ALIGN_LEFT | NVG_ALIGN_CENTER | NVG_ALIGN_RIGHT);
@@ -2873,8 +2879,8 @@ void nvgTextBoxBounds(NVGcontext* ctx, float x, float y, float breakRowWidth, co
 
 	state->textAlign = NVG_ALIGN_LEFT | valign;
 
-	minx = maxx = x;
-	miny = maxy = y;
+	minx = maxx = 0;
+	miny = maxy = 0;
 
 	fonsSetSize(ctx->fs, state->fontSize*scale);
 	fonsSetSpacing(ctx->fs, state->letterSpacing*scale);
@@ -2896,15 +2902,15 @@ void nvgTextBoxBounds(NVGcontext* ctx, float x, float y, float breakRowWidth, co
 				dx = breakRowWidth*0.5f - row->width*0.5f;
 			else if (haling & NVG_ALIGN_RIGHT)
 				dx = breakRowWidth - row->width;
-			rminx = x + row->minx + dx;
-			rmaxx = x + row->maxx + dx;
+			rminx = row->minx + dx;
+			rmaxx = row->maxx + dx;
 			minx = nvg__minf(minx, rminx);
 			maxx = nvg__maxf(maxx, rmaxx);
 			// Vertical bounds.
-			miny = nvg__minf(miny, y + rminy);
-			maxy = nvg__maxf(maxy, y + rmaxy);
+			miny = nvg__minf(miny, yoff + rminy);
+			maxy = nvg__maxf(maxy, yoff + rmaxy);
 
-			y += lineh * state->lineHeight;
+			yoff += lineh * state->lineHeight;
 		}
 		string = rows[nrows-1].next;
 	}
@@ -2912,10 +2918,10 @@ void nvgTextBoxBounds(NVGcontext* ctx, float x, float y, float breakRowWidth, co
 	state->textAlign = oldAlign;
 
 	if (bounds != NULL) {
-		bounds[0] = minx;
-		bounds[1] = miny;
-		bounds[2] = maxx;
-		bounds[3] = maxy;
+		bounds[0] = minx + x;
+		bounds[1] = miny + y;
+		bounds[2] = maxx + x;
+		bounds[3] = maxy + y;
 	}
 }
 

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -396,10 +396,10 @@ void nvgCancelFrame(NVGcontext* ctx)
 
 void nvgEndFrame(NVGcontext* ctx)
 {
-    if(ctx->textTextureDirty != 0) {
-        nvg__flushTextTexture(ctx);
-        ctx->textTextureDirty=0;
-    }
+	if(ctx->textTextureDirty != 0) {
+		nvg__flushTextTexture(ctx);
+		ctx->textTextureDirty=0;
+	}
 	ctx->params.renderFlush(ctx->params.userPtr);
 	if (ctx->fontImageIdx != 0) {
 		int fontImage = ctx->fontImages[ctx->fontImageIdx];
@@ -2521,7 +2521,6 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 		nvgTransformPoint(&c[2],&c[3], state->xform, q.x1+x, q.y0+y);
 		nvgTransformPoint(&c[4],&c[5], state->xform, q.x1+x, q.y1+y);
 		nvgTransformPoint(&c[6],&c[7], state->xform, q.x0+x, q.y1+y);
-
 		// Create triangles
 		if (nverts+6 <= cverts) {
 			nvg__vset(&verts[nverts], c[0], c[1], q.s0, q.t0); nverts++;

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2493,7 +2493,7 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	verts = nvg__allocTempVerts(ctx, cverts);
 	if (verts == NULL) return x;
 
-	fonsTextIterInit(ctx->fs, &iter, 0.0f, 0.0f, string, end, FONS_GLYPH_BITMAP_REQUIRED);
+	fonsTextIterInit(ctx->fs, &iter, 0, 0, string, end, FONS_GLYPH_BITMAP_REQUIRED);
 	prevIter = iter;
 	while (fonsTextIterNext(ctx->fs, &iter, &q)) {
 		float c[4*2];
@@ -2533,7 +2533,7 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 		}
 	}
 
-	// TODO: add back-end bit to do this just once per frame.
+	// Back-end bit to do this just once per frame.
 	ctx->textTextureDirty = 1;
 	nvg__renderText(ctx, verts, nverts);
 	return iter.nextx + x;
@@ -2576,7 +2576,6 @@ int nvgTextGlyphPositions(NVGcontext* ctx, float x, float y, const char* string,
 {
 	NVGstate* state = nvg__getState(ctx);
 	float scale = nvg__getFontScale(state) * ctx->devicePxRatio;
-	float invscale = 1.0f / scale;
 	FONStextIter iter, prevIter;
 	FONSquad q;
 	int npos = 0;
@@ -2595,7 +2594,7 @@ int nvgTextGlyphPositions(NVGcontext* ctx, float x, float y, const char* string,
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 
-	fonsTextIterInit(ctx->fs, &iter, x*scale, y*scale, string, end, FONS_GLYPH_BITMAP_OPTIONAL);
+	fonsTextIterInit(ctx->fs, &iter, 0, 0, string, end, FONS_GLYPH_BITMAP_OPTIONAL);
 	prevIter = iter;
 	while (fonsTextIterNext(ctx->fs, &iter, &q)) {
 		if (iter.prevGlyphIndex < 0 && nvg__allocTextAtlas(ctx)) { // can not retrieve glyph?
@@ -2604,9 +2603,9 @@ int nvgTextGlyphPositions(NVGcontext* ctx, float x, float y, const char* string,
 		}
 		prevIter = iter;
 		positions[npos].str = iter.str;
-		positions[npos].x = iter.x * invscale;
-		positions[npos].minx = nvg__minf(iter.x, q.x0) * invscale;
-		positions[npos].maxx = nvg__maxf(iter.nextx, q.x1) * invscale;
+		positions[npos].x = iter.x + x;
+		positions[npos].minx = nvg__minf(iter.x, q.x0) + x;
+		positions[npos].maxx = nvg__maxf(iter.nextx, q.x1) + x;
 		npos++;
 		if (npos >= maxPositions)
 			break;
@@ -2843,10 +2842,10 @@ float nvgTextBounds(NVGcontext* ctx, float x, float y, const char* string, const
 	fonsSetAlign(ctx->fs, state->textAlign);
 	fonsSetFont(ctx->fs, state->fontId);
 
-	width = fonsTextBounds(ctx->fs, 0.0f, 0.0f, string, end, bounds);
+	width = fonsTextBounds(ctx->fs, 0, 0, string, end, bounds);
 	if (bounds != NULL) {
 		// Use line bounds for height.
-		fonsLineBounds(ctx->fs, 0.0f, &bounds[1], &bounds[3]);
+		fonsLineBounds(ctx->fs, 0, &bounds[1], &bounds[3]);
         bounds[0] += x;
         bounds[1] += y;
         bounds[2] += x;

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2518,9 +2518,9 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 		}
 		// Transform corners.
 		nvgTransformPoint(&c[0],&c[1], state->xform, q.x0+x, q.y0+y);
-        nvgTransformPoint(&c[2],&c[3], state->xform, q.x1+x, q.y0+y);
-        nvgTransformPoint(&c[4],&c[5], state->xform, q.x1+x, q.y1+y);
-        nvgTransformPoint(&c[6],&c[7], state->xform, q.x0+x, q.y1+y);
+		nvgTransformPoint(&c[2],&c[3], state->xform, q.x1+x, q.y0+y);
+		nvgTransformPoint(&c[4],&c[5], state->xform, q.x1+x, q.y1+y);
+		nvgTransformPoint(&c[6],&c[7], state->xform, q.x0+x, q.y1+y);
 
 		// Create triangles
 		if (nverts+6 <= cverts) {
@@ -2846,10 +2846,10 @@ float nvgTextBounds(NVGcontext* ctx, float x, float y, const char* string, const
 	if (bounds != NULL) {
 		// Use line bounds for height.
 		fonsLineBounds(ctx->fs, 0, &bounds[1], &bounds[3]);
-        bounds[0] += x;
-        bounds[1] += y;
-        bounds[2] += x;
-        bounds[3] += y;
+		bounds[0] += x;
+		bounds[1] += y;
+		bounds[2] += x;
+		bounds[3] += y;
 	}
 	return width * invscale;
 }

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2477,6 +2477,7 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 	FONSquad q;
 	NVGvertex* verts;
 	float scale = nvg__getFontScale(state) * ctx->devicePxRatio;
+	float invscale = 1.0f / scale;
 	int cverts = 0;
 	int nverts = 0;
 	int isFlipped = nvg__isTransformFlipped(state->xform);
@@ -2520,10 +2521,10 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 			tmp = q.t0; q.t0 = q.t1; q.t1 = tmp;
 		}
 		// Transform corners.
-		nvgTransformPoint(&c[0],&c[1], state->xform, q.x0+x, q.y0+y);
-		nvgTransformPoint(&c[2],&c[3], state->xform, q.x1+x, q.y0+y);
-		nvgTransformPoint(&c[4],&c[5], state->xform, q.x1+x, q.y1+y);
-		nvgTransformPoint(&c[6],&c[7], state->xform, q.x0+x, q.y1+y);
+		nvgTransformPoint(&c[0],&c[1], state->xform, q.x0*invscale + x, q.y0*invscale + y);
+		nvgTransformPoint(&c[2],&c[3], state->xform, q.x1*invscale + x, q.y0*invscale + y);
+		nvgTransformPoint(&c[4],&c[5], state->xform, q.x1*invscale + x, q.y1*invscale + y);
+		nvgTransformPoint(&c[6],&c[7], state->xform, q.x0*invscale + x, q.y1*invscale + y);
 		// Create triangles
 		if (nverts+6 <= cverts) {
 			nvg__vset(&verts[nverts], c[0], c[1], q.s0, q.t0); nverts++;
@@ -2578,6 +2579,7 @@ int nvgTextGlyphPositions(NVGcontext* ctx, float x, float y, const char* string,
 {
 	NVGstate* state = nvg__getState(ctx);
 	float scale = nvg__getFontScale(state) * ctx->devicePxRatio;
+	float invscale = 1.0f / scale;
 	FONStextIter iter, prevIter;
 	FONSquad q;
 	int npos = 0;
@@ -2605,9 +2607,9 @@ int nvgTextGlyphPositions(NVGcontext* ctx, float x, float y, const char* string,
 		}
 		prevIter = iter;
 		positions[npos].str = iter.str;
-		positions[npos].x = iter.x + x;
-		positions[npos].minx = nvg__minf(iter.x, q.x0) + x;
-		positions[npos].maxx = nvg__maxf(iter.nextx, q.x1) + x;
+		positions[npos].x = iter.x * invscale + x;
+		positions[npos].minx = nvg__minf(iter.x, q.x0) * invscale + x;
+		positions[npos].maxx = nvg__maxf(iter.nextx, q.x1) * invscale + x;
 		npos++;
 		if (npos >= maxPositions)
 			break;
@@ -2848,10 +2850,10 @@ float nvgTextBounds(NVGcontext* ctx, float x, float y, const char* string, const
 	if (bounds != NULL) {
 		// Use line bounds for height.
 		fonsLineBounds(ctx->fs, 0, &bounds[1], &bounds[3]);
-		bounds[0] += x;
-		bounds[1] += y;
-		bounds[2] += x;
-		bounds[3] += y;
+		bounds[0] = bounds[0] * invscale + x;
+		bounds[1] = bounds[1] * invscale + y;
+		bounds[2] = bounds[2] * invscale + x;
+		bounds[3] = bounds[3] * invscale + y;
 	}
 	return width * invscale;
 }

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -135,7 +135,6 @@ struct NVGcontext {
 	int fillTriCount;
 	int strokeTriCount;
 	int textTriCount;
-	int textTextureDirty;
 };
 
 static float nvg__sqrtf(float a) { return sqrtf(a); }
@@ -167,7 +166,6 @@ static float nvg__normalize(float *x, float* y)
 	return d;
 }
 
-static void nvg__flushTextTexture(NVGcontext* ctx);
 
 static void nvg__deletePathCache(NVGpathCache* c)
 {
@@ -389,7 +387,6 @@ void nvgBeginFrame(NVGcontext* ctx, float windowWidth, float windowHeight, float
 	ctx->fillTriCount = 0;
 	ctx->strokeTriCount = 0;
 	ctx->textTriCount = 0;
-	ctx->textTextureDirty = 0;
 }
 
 void nvgCancelFrame(NVGcontext* ctx)
@@ -399,10 +396,6 @@ void nvgCancelFrame(NVGcontext* ctx)
 
 void nvgEndFrame(NVGcontext* ctx)
 {
-	if(ctx->textTextureDirty != 0) {
-		nvg__flushTextTexture(ctx);
-		ctx->textTextureDirty=0;
-	}
 	ctx->params.renderFlush(ctx->params.userPtr);
 	if (ctx->fontImageIdx != 0) {
 		int fontImage = ctx->fontImages[ctx->fontImageIdx];
@@ -2536,10 +2529,11 @@ float nvgText(NVGcontext* ctx, float x, float y, const char* string, const char*
 		}
 	}
 
-	// Back-end bit to do this just once per frame.
-	ctx->textTextureDirty = 1;
+	// TODO: add back-end bit to do this just once per frame.
+	nvg__flushTextTexture(ctx);
+
 	nvg__renderText(ctx, verts, nverts);
-	return iter.nextx + x;
+	return iter.nextx * invscale + x;
 }
 
 void nvgTextBox(NVGcontext* ctx, float x, float y, float breakRowWidth, const char* string, const char* end)


### PR DESCRIPTION
Font stash returns glyph positions in integer pixels. When rendering text at floating point positions,  glyph positions get rounded to the nearest pixel. This is particularly noticeable with animated moving text, giving the appearance of jitter relative to other animated graphics. To circumvent this problem, this PR renders text at the origin (0,0) and then translates it afterwards to the proper floating point pixel location. This is possible because text rendering is shift invariant. In addition to updating the draw text call, all the methods for getting text bounds and positions have been updated as well.

![dump](https://user-images.githubusercontent.com/2365573/184545526-421cc6f0-96e2-4dc8-b70c-792151cee08d.png)

 