### PR TITLE
Allows setting the `NVG_MAX_STATES` number.

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -45,7 +45,10 @@
 #define NVG_INIT_POINTS_SIZE 128
 #define NVG_INIT_PATHS_SIZE 16
 #define NVG_INIT_VERTS_SIZE 256
+
+#ifndef NVG_MAX_STATES
 #define NVG_MAX_STATES 32
+#endif
 
 #define NVG_KAPPA90 0.5522847493f	// Length proportional to radius of a cubic bezier handle for 90deg arcs.
 


### PR DESCRIPTION
Currently, `NVG_MAX_STATES` is set to 32. But it’s not enough sometimes in my case. This commit allows defining the preferred `NVG_MAX_STATES` number.