### PR TITLE
fix-kern

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2602,7 +2602,7 @@ int nvgTextGlyphPositions(NVGcontext* ctx, float x, float y, const char* string,
 		}
 		prevIter = iter;
 		positions[npos].str = iter.str;
-		positions[npos].x = iter.x * invscale;
+		positions[npos].x = (iter.x + iter.kern_adjust) * invscale;
 		positions[npos].minx = nvg__minf(iter.x, q.x0) * invscale;
 		positions[npos].maxx = nvg__maxf(iter.nextx, q.x1) * invscale;
 		npos++;


### PR DESCRIPTION
Make `NVGglyphPosition::x` values filled by `nvgTextGlyphPositions()` correctly adjusted by kerning.
So calling `nvgText()` with these coordinates on any sub-string will result in exactly same glyph placements,

Problem occurs when we need to draw text in multiple chunks, eg: to change a fill color for selected part of a text.
Before this fix, drawing every chunk with `nvgText()` would suffer from not being adjusted by kerning with the last glyph of the previous chunk.