### PR TITLE
Fix comparison in nvg__flattenPaths()

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -1341,7 +1341,7 @@ static void nvg__flattenPaths(NVGcontext* ctx)
 	float* p;
 	float area;
 
-	if (cache->npaths > 0)
+	if (cache->npaths == 0)
 		return;
 
 	// Flatten


### PR DESCRIPTION
A check `if (cache->npaths > 0)` on function entry does not make sense given the loop `for (j = 0; j < cache->npaths; j++)` below. If an entry check passes, then loop will never make at least one iteration. Fix initial check which appears to be an optimization for the case when there are no cached paths.