### PR TITLE
Define missing `NANOVG_GLEW` for Linux configurations

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -152,6 +152,7 @@ solution "nanovg"
 		configuration { "linux" }
 			 linkoptions { "`pkg-config --libs glfw3`" }
 			 links { "GL", "GLU", "m", "GLEW" }
+			 defines { "NANOVG_GLEW" }
 
 		configuration { "windows" }
 			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32", "kernel32" }
@@ -180,6 +181,7 @@ solution "nanovg"
 		configuration { "linux" }
 			 linkoptions { "`pkg-config --libs glfw3`" }
 			 links { "GL", "GLU", "m", "GLEW" }
+			 defines { "NANOVG_GLEW" }
 
 		configuration { "windows" }
 			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32", "kernel32" }
@@ -208,6 +210,7 @@ solution "nanovg"
 		configuration { "linux" }
 			 linkoptions { "`pkg-config --libs glfw3`" }
 			 links { "GL", "GLU", "m", "GLEW" }
+			 defines { "NANOVG_GLEW" }
 
 		configuration { "windows" }
 			 links { "glfw3", "gdi32", "winmm", "user32", "GLEW", "glu32","opengl32", "kernel32" }


### PR DESCRIPTION
When building nanovg on Debian unstable with `-Werror=implicit-function-declaration` in `CFLAGS`, three of the examples fail to build due to undefined functions. It seems that `NANOVG_GLEW` definition is missing in Linux configurations of these three examples despite being present in Windows configurations. This PR fixes the issue by adding `NANOVG_GLEW` to Linux configurations for these three examples.