### PR TITLE
Fix iPhone PNG color issues when loading images from memory in NanoVG

### DIFF
--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -814,6 +814,8 @@ int nvgCreateImage(NVGcontext* ctx, const char* filename, int imageFlags)
 int nvgCreateImageMem(NVGcontext* ctx, int imageFlags, unsigned char* data, int ndata)
 {
 	int w, h, n, image;
+	stbi_set_unpremultiply_on_load(1);
+	stbi_convert_iphone_png_to_rgb(1);
 	unsigned char* img = stbi_load_from_memory(data, ndata, &w, &h, &n, 4);
 	if (img == NULL) {
 //		printf("Failed to load %s - %s\n", filename, stbi_failure_reason());


### PR DESCRIPTION
## Background
When images are loaded via `nvgCreateImageMem`, iPhone PNG assets can show incorrect colors on Apple platforms.

## Root Cause
`nvgCreateImage` already enables STB iPhone PNG compatibility flags:
- `stbi_set_unpremultiply_on_load(1)`
- `stbi_convert_iphone_png_to_rgb(1)`

But `nvgCreateImageMem` did not, so file-based and memory-based loading paths behaved differently.

## Changes
- In `src/nanovg.c`, add the same two STB compatibility calls in `nvgCreateImageMem(...)` before `stbi_load_from_memory(...)`.